### PR TITLE
Fix page slug search

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -9,7 +9,7 @@ class PageController extends Controller
 {
     public function show($slug)
     {
-        $page = Page::where('title', $slug)->firstOrFail();
+        $page = Page::where('slug', $slug)->firstOrFail();
         return view('pages.show', compact('page'));
     }
 }

--- a/database/migrations/2025_02_17_093943_create_pages_table.php
+++ b/database/migrations/2025_02_17_093943_create_pages_table.php
@@ -11,12 +11,13 @@ return new class extends Migration
      */
 	public function up()
 	{
-		Schema::create('pages', function (Blueprint $table) {
-			$table->id();
-			$table->string('title')->unique();
-			$table->text('content');
-			$table->timestamps();
-		});
+                Schema::create('pages', function (Blueprint $table) {
+                        $table->id();
+                        $table->string('title');
+                        $table->string('slug')->unique();
+                        $table->text('content');
+                        $table->timestamps();
+                });
 	}
 
     /**

--- a/tests/Feature/PageControllerTest.php
+++ b/tests/Feature/PageControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Page;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_page_can_be_resolved_by_slug(): void
+    {
+        $page = Page::create([
+            'title' => 'About Us',
+            'slug' => 'about-us',
+            'content' => 'content'
+        ]);
+
+        $response = $this->get('/page/'.$page->slug);
+
+        $response->assertStatus(200);
+        $response->assertSee('content');
+    }
+}


### PR DESCRIPTION
## Summary
- add slug column in pages migration
- use slug to load pages
- test page retrieval by slug

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684ff279c5f8832c9ee2cdfd6ff9dbc5