### PR TITLE
Add optional invite code field on registration

### DIFF
--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -29,6 +29,7 @@ class RegisterController extends Controller
             'username' => 'required|string|max:30|unique:account.account,login',
             'real_name' => 'required|string|max:255',
             'age' => 'required|integer|min:13',
+            'reffer' => 'nullable|string|max:255',
             'email' => [
                 'required',
                 'email',
@@ -75,16 +76,18 @@ class RegisterController extends Controller
             $accountStatus = $requireEmailVerification ? 'PENDING' : 'OK';
 
             // Inserare cont
-            DB::connection('account')->statement("
-                INSERT INTO account (login, password, email, status, created_at, updated_at, create_time, activation_token) 
-                VALUES (?, PASSWORD(?), ?, ?, NOW(), NOW(), NOW(), ?)
-            ", [
-                $request->username,
-                $request->password,
-                $request->email,
-                $accountStatus,
-                $activation_token,
-            ]);
+            DB::connection('account')->statement(
+                "INSERT INTO account (login, password, email, status, created_at, updated_at, create_time, activation_token, reffer)
+                VALUES (?, PASSWORD(?), ?, ?, NOW(), NOW(), NOW(), ?, ?)",
+                [
+                    $request->username,
+                    $request->password,
+                    $request->email,
+                    $accountStatus,
+                    $activation_token,
+                    $request->reffer,
+                ]
+            );
 
             // Dacă activarea prin email este necesară, trimitem email-ul
             if ($requireEmailVerification) {

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -22,5 +22,6 @@ class Account extends Model
         'register_ip',
         'ban_until',
         'ban_reason',
+        'reffer',
     ];
 }

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -91,6 +91,7 @@ return [
     'page_register_username' => 'Username',
     'page_register_real_name' => 'Real Name',
     'page_register_age' => 'Age',
+    'page_register_invite_code' => 'Invitation Code (optional)',
     'page_register_email' => 'Email',
     'page_register_repeat_email' => 'Repeat Email',
     'page_register_password' => 'Password',

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -91,6 +91,7 @@ return [
     'page_register_username' => 'Nume utilizator',
     'page_register_real_name' => 'Numele real',
     'page_register_age' => 'Vârsta',
+    'page_register_invite_code' => 'Cod de invitație (opțional)',
     'page_register_email' => 'Email',
     'page_register_repeat_email' => 'Repetă Email',
     'page_register_password' => 'Parolă',

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -108,12 +108,27 @@
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
                                             </svg>
                                         </div>
-                                        <input type="number" name="age" id="age" min="13" max="100"
+                                <input type="number" name="age" id="age" min="13" max="100"
                                             class="w-full pl-10 pr-3 py-2 bg-dark-700 border border-green-900 focus:border-green-500 rounded-md text-gray-200 focus:outline-none focus:ring-1 focus:ring-green-500"
                                             value="{{ old('age') }}" required>
                                     </div>
                                 </div>
-                                
+
+                                <!-- Invitation Code (optional) -->
+                                <div class="relative form-group">
+                                    <label class="block text-sm font-medium text-green-400 mb-1">{{ __('messages.page_register_invite_code') }}</label>
+                                    <div class="relative">
+                                        <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
+                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                                            </svg>
+                                        </div>
+                                        <input type="text" name="reffer" id="reffer"
+                                            class="w-full pl-10 pr-3 py-2 bg-dark-700 border border-green-900 focus:border-green-500 rounded-md text-gray-200 focus:outline-none focus:ring-1 focus:ring-green-500"
+                                            value="{{ old('reffer') }}">
+                                    </div>
+                                </div>
+
                                 <!-- Password -->
                                 <div class="relative form-group">
                                     <label class="block text-sm font-medium text-green-400 mb-1">Password</label>


### PR DESCRIPTION
## Summary
- add messages for invite code
- allow optional `reffer` field on register form
- save invite code when creating account
- include `reffer` in Account model

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850046b3cdc832cbd1c29dce7c294cc