### PR TITLE
Add toggle for referral field

### DIFF
--- a/app/Filament/Resources/SettingResource.php
+++ b/app/Filament/Resources/SettingResource.php
@@ -13,6 +13,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Tables\Columns\TextColumn;
 
 class SettingResource extends Resource
@@ -29,12 +30,20 @@ class SettingResource extends Resource
                     ->label('Setting Key')
                     ->required()
                     ->maxLength(255)
-                    ->unique(ignoreRecord: true),
+                    ->unique(ignoreRecord: true)
+                    ->disabled(fn (?Setting $record) => $record !== null),
+
+                Toggle::make('value')
+                    ->label('Enable Refer')
+                    ->visible(fn (callable $get) => $get('key') === 'reffer_enabled')
+                    ->dehydrateStateUsing(fn ($state) => $state ? '1' : '0')
+                    ->formatStateUsing(fn ($state) => (bool) $state),
 
                 TextInput::make('value')
                     ->label('Setting Value')
                     ->required()
-                    ->maxLength(1000),
+                    ->maxLength(1000)
+                    ->visible(fn (callable $get) => $get('key') !== 'reffer_enabled'),
             ]);
     }
 

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -10,14 +10,16 @@ use App\Models\Account;
 use App\Mail\AccountActivationMail;
 use Illuminate\Support\Str;
 use Anhskohbo\NoCaptcha\NoCaptcha;
+use App\Models\Setting;
 
 class RegisterController extends Controller
 {
     public function showRegisterForm()
     {
-		return view('register', [
-			'title' => ' - Register', // Titlul pentru pagina de înregistrare
-		]);
+        return view('register', [
+            'title' => ' - Register', // Titlul pentru pagina de înregistrare
+            'refferEnabled' => Setting::isEnabled('reffer_enabled', false),
+        ]);
     }
 
     public function register(Request $request)
@@ -29,7 +31,7 @@ class RegisterController extends Controller
             'username' => 'required|string|max:30|unique:account.account,login',
             'real_name' => 'required|string|max:255',
             'age' => 'required|integer|min:13',
-            'reffer' => 'nullable|string|max:255',
+            'reffer' => Setting::isEnabled('reffer_enabled', false) ? 'nullable|string|max:255' : 'sometimes|nullable',
             'email' => [
                 'required',
                 'email',
@@ -85,7 +87,7 @@ class RegisterController extends Controller
                     $request->email,
                     $accountStatus,
                     $activation_token,
-                    $request->reffer,
+                    Setting::isEnabled('reffer_enabled', false) ? $request->reffer : null,
                 ]
             );
 

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -4,7 +4,31 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Generic key/value application setting.
+ */
 class Setting extends Model
 {
-    //
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['key', 'value'];
+
+    /**
+     * Retrieve a setting value by key.
+     */
+    public static function getValue(string $key, $default = null)
+    {
+        return static::query()->where('key', $key)->value('value') ?? $default;
+    }
+
+    /**
+     * Determine if a boolean setting is enabled.
+     */
+    public static function isEnabled(string $key, bool $default = false): bool
+    {
+        return filter_var(static::getValue($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Setting;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
@@ -49,5 +50,12 @@ class DatabaseSeeder extends Seeder
             'email' => 'player@metin2.com',
         ]);
         $playerUser->assignRole('player');
+
+        // Default settings
+        Setting::firstOrCreate([
+            'key' => 'reffer_enabled',
+        ], [
+            'value' => '1',
+        ]);
     }
 }

--- a/resources/views/register.blade.php
+++ b/resources/views/register.blade.php
@@ -114,20 +114,22 @@
                                     </div>
                                 </div>
 
-                                <!-- Invitation Code (optional) -->
-                                <div class="relative form-group">
-                                    <label class="block text-sm font-medium text-green-400 mb-1">{{ __('messages.page_register_invite_code') }}</label>
-                                    <div class="relative">
-                                        <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
-                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                                            </svg>
+                                @if ($refferEnabled)
+                                    <!-- Invitation Code (optional) -->
+                                    <div class="relative form-group">
+                                        <label class="block text-sm font-medium text-green-400 mb-1">{{ __('messages.page_register_invite_code') }}</label>
+                                        <div class="relative">
+                                            <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
+                                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                                                </svg>
+                                            </div>
+                                            <input type="text" name="reffer" id="reffer"
+                                                class="w-full pl-10 pr-3 py-2 bg-dark-700 border border-green-900 focus:border-green-500 rounded-md text-gray-200 focus:outline-none focus:ring-1 focus:ring-green-500"
+                                                value="{{ old('reffer') }}">
                                         </div>
-                                        <input type="text" name="reffer" id="reffer"
-                                            class="w-full pl-10 pr-3 py-2 bg-dark-700 border border-green-900 focus:border-green-500 rounded-md text-gray-200 focus:outline-none focus:ring-1 focus:ring-green-500"
-                                            value="{{ old('reffer') }}">
                                     </div>
-                                </div>
+                                @endif
 
                                 <!-- Password -->
                                 <div class="relative form-group">


### PR DESCRIPTION
## Summary
- allow storing key/value settings
- add Filament toggle for enabling the referral field
- show the referral field on register page only when enabled
- seed default setting

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685005d7e02c832c8566350b233fc5fd