### PR TITLE
Add gallery with comments and Filament resource

### DIFF
--- a/app/Filament/Resources/GalleryItemResource.php
+++ b/app/Filament/Resources/GalleryItemResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\GalleryItemResource\Pages;
+use App\Models\GalleryItem;
+use Filament\Forms;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\FileUpload;
+use Filament\Resources\Resource;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class GalleryItemResource extends Resource
+{
+    protected static ?string $model = GalleryItem::class;
+    protected static ?string $navigationIcon = 'heroicon-o-photo';
+    protected static ?string $navigationGroup = 'Content Management';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+                FileUpload::make('image_path')
+                    ->label('Photo')
+                    ->disk('public')
+                    ->directory('gallery'),
+                TextInput::make('video_url')
+                    ->label('YouTube URL'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')->sortable()->searchable(),
+                TextColumn::make('created_at')->dateTime()->sortable()->label('Created'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListGalleryItems::route('/'),
+            'create' => Pages\CreateGalleryItem::route('/create'),
+            'edit' => Pages\EditGalleryItem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/GalleryItemResource/Pages/CreateGalleryItem.php
+++ b/app/Filament/Resources/GalleryItemResource/Pages/CreateGalleryItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\GalleryItemResource\Pages;
+
+use App\Filament\Resources\GalleryItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateGalleryItem extends CreateRecord
+{
+    protected static string $resource = GalleryItemResource::class;
+}

--- a/app/Filament/Resources/GalleryItemResource/Pages/EditGalleryItem.php
+++ b/app/Filament/Resources/GalleryItemResource/Pages/EditGalleryItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\GalleryItemResource\Pages;
+
+use App\Filament\Resources\GalleryItemResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditGalleryItem extends EditRecord
+{
+    protected static string $resource = GalleryItemResource::class;
+}

--- a/app/Filament/Resources/GalleryItemResource/Pages/ListGalleryItems.php
+++ b/app/Filament/Resources/GalleryItemResource/Pages/ListGalleryItems.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\GalleryItemResource\Pages;
+
+use App\Filament\Resources\GalleryItemResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListGalleryItems extends ListRecords
+{
+    protected static string $resource = GalleryItemResource::class;
+}

--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\GalleryItem;
+use App\Models\GalleryComment;
+use Illuminate\Http\Request;
+
+class GalleryController extends Controller
+{
+    public function index()
+    {
+        $photos = GalleryItem::whereNotNull('image_path')->latest()->get();
+        $videos = GalleryItem::whereNotNull('video_url')->latest()->get();
+        return view('gallery.index', compact('photos', 'videos'));
+    }
+
+    public function show(GalleryItem $item)
+    {
+        $comments = $item->comments()->latest()->get();
+        return view('gallery.show', compact('item', 'comments'));
+    }
+
+    public function comment(Request $request, GalleryItem $item)
+    {
+        $request->validate([
+            'content' => 'required|string',
+        ]);
+
+        $item->comments()->create([
+            'author' => $request->input('author'),
+            'content' => $request->input('content'),
+        ]);
+
+        return redirect()->back();
+    }
+
+    public function like(GalleryComment $comment)
+    {
+        $comment->increment('likes');
+        return redirect()->back();
+    }
+
+    public function dislike(GalleryComment $comment)
+    {
+        $comment->increment('dislikes');
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -4,13 +4,15 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\News;
+use App\Models\GalleryItem;
 
 class WelcomeController extends Controller
 {
     public function index()
     {
         $latestNews = News::latest()->take(3)->get();
-        return view('welcome', compact('latestNews'));
+        $latestMedia = GalleryItem::latest()->take(4)->get();
+        return view('welcome', compact('latestNews', 'latestMedia'));
     }
 }
 

--- a/app/Models/GalleryComment.php
+++ b/app/Models/GalleryComment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GalleryComment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['gallery_item_id', 'author', 'content', 'likes', 'dislikes'];
+
+    public function galleryItem()
+    {
+        return $this->belongsTo(GalleryItem::class);
+    }
+}

--- a/app/Models/GalleryItem.php
+++ b/app/Models/GalleryItem.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GalleryItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['title', 'image_path', 'video_url'];
+
+    public function comments()
+    {
+        return $this->hasMany(GalleryComment::class);
+    }
+}

--- a/database/migrations/2025_04_01_000000_create_gallery_items_table.php
+++ b/database/migrations/2025_04_01_000000_create_gallery_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('gallery_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('image_path')->nullable();
+            $table->string('video_url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gallery_items');
+    }
+};

--- a/database/migrations/2025_04_01_000001_create_gallery_comments_table.php
+++ b/database/migrations/2025_04_01_000001_create_gallery_comments_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('gallery_comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('gallery_item_id')->constrained()->cascadeOnDelete();
+            $table->string('author')->nullable();
+            $table->text('content');
+            $table->unsignedInteger('likes')->default(0);
+            $table->unsignedInteger('dislikes')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gallery_comments');
+    }
+};

--- a/resources/views/gallery/index.blade.php
+++ b/resources/views/gallery/index.blade.php
@@ -1,0 +1,27 @@
+@extends('layout')
+
+@section('title', 'Gallery')
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
+    <h2 class="text-xl font-semibold mb-4 text-green-400">Photos</h2>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        @foreach ($photos as $photo)
+            <a href="{{ route('gallery.show', $photo) }}" class="block border border-gray-700 rounded overflow-hidden">
+                <img src="{{ asset('storage/' . $photo->image_path) }}" class="w-full h-full object-cover" />
+            </a>
+        @endforeach
+    </div>
+</div>
+
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    <h2 class="text-xl font-semibold mb-4 text-green-400">Videos</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        @foreach ($videos as $video)
+            <div class="aspect-video">
+                <iframe src="https://www.youtube.com/embed/{{ \Illuminate\Support\Str::afterLast($video->video_url, '=') }}" class="w-full h-full" frameborder="0" allowfullscreen></iframe>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endsection

--- a/resources/views/gallery/show.blade.php
+++ b/resources/views/gallery/show.blade.php
@@ -1,0 +1,44 @@
+@extends('layout')
+
+@section('title', $item->title)
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
+    <h2 class="text-2xl font-bold mb-4 text-green-400">{{ $item->title }}</h2>
+    @if ($item->image_path)
+        <img src="{{ asset('storage/' . $item->image_path) }}" class="w-full rounded" />
+    @elseif ($item->video_url)
+        <div class="aspect-video">
+            <iframe src="https://www.youtube.com/embed/{{ \Illuminate\Support\Str::afterLast($item->video_url, '=') }}" class="w-full h-full" frameborder="0" allowfullscreen></iframe>
+        </div>
+    @endif
+</div>
+
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    <h3 class="text-lg font-semibold mb-4 text-green-400">Comments</h3>
+    <form action="{{ route('gallery.comment', $item) }}" method="POST" class="mb-4">
+        @csrf
+        <input type="text" name="author" placeholder="Your name" class="w-full mb-2 p-2 bg-gray-800 text-white rounded" />
+        <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+        <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">Submit</button>
+    </form>
+
+    <div class="space-y-4">
+        @foreach ($comments as $comment)
+            <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
+                <p class="text-sm text-gray-300">{{ $comment->content }}</p>
+                <div class="text-xs text-gray-500 mt-2 flex items-center gap-2">
+                    <form action="{{ route('gallery.comments.like', $comment) }}" method="POST" class="inline">
+                        @csrf
+                        <button>👍 {{ $comment->likes }}</button>
+                    </form>
+                    <form action="{{ route('gallery.comments.dislike', $comment) }}" method="POST" class="inline">
+                        @csrf
+                        <button>👎 {{ $comment->dislikes }}</button>
+                    </form>
+                </div>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -117,14 +117,18 @@
     <h2 class="text-xl font-semibold mb-4 text-green-400 text-center">{{ __('Game Screenshots') }}</h2>
     
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        @for ($i = 1; $i <= 4; $i++)
-            <div class="relative overflow-hidden rounded-lg border border-gray-700 aspect-video bg-gray-800 hover:border-green-500 transition-all duration-300 transform hover:scale-105 group">
-                <img src="/images/w.png" alt="Game Screenshot {{ $i }}" class="w-full h-full object-cover">
+        @foreach ($latestMedia as $media)
+            <a href="{{ route('gallery.show', $media) }}" class="relative overflow-hidden rounded-lg border border-gray-700 aspect-video bg-gray-800 hover:border-green-500 transition-all duration-300 transform hover:scale-105 group">
+                @if ($media->image_path)
+                    <img src="{{ asset('storage/' . $media->image_path) }}" alt="{{ $media->title }}" class="w-full h-full object-cover" />
+                @else
+                    <iframe src="https://www.youtube.com/embed/{{ \Illuminate\Support\Str::afterLast($media->video_url, '=') }}" class="w-full h-full" frameborder="0" allowfullscreen></iframe>
+                @endif
                 <div class="absolute inset-0 bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                     <span class="text-green-400 text-2xl">🔍</span>
                 </div>
-            </div>
-        @endfor
+            </a>
+        @endforeach
     </div>
     
     <div class="text-center mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\PasswordController;
 use App\Http\Controllers\ItemShopController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\NewsController;
+use App\Http\Controllers\GalleryController;
 
 // Aplica middleware-ul global pentru toate rutele
 Route::middleware([LanguageMiddleware::class])->group(function () {
@@ -39,6 +40,13 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
         Route::post('/news/{slug}/comment', [NewsController::class, 'comment'])->name('news.comment');
         Route::post('/comments/{comment}/like', [NewsController::class, 'like'])->name('comments.like');
         Route::post('/comments/{comment}/dislike', [NewsController::class, 'dislike'])->name('comments.dislike');
+
+        // Gallery routes
+        Route::get('/screenshots', [GalleryController::class, 'index'])->name('gallery.index');
+        Route::get('/gallery/{item}', [GalleryController::class, 'show'])->name('gallery.show');
+        Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
+        Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
+        Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
 	
 	Route::post('/metin2/login', [Metin2AuthController::class, 'login'])->name('metin2.login');
 	Route::post('/metin2/logout', [Metin2AuthController::class, 'logout'])->name('metin2.logout');


### PR DESCRIPTION
## Summary
- enable gallery item management from Filament
- allow gallery items to store photos or YouTube videos
- display gallery items on homepage and dedicated pages
- implement comments with likes/dislikes for gallery items

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685070187bdc832c8214f39cff6b8155