### PR TITLE
Add password reset

### DIFF
--- a/app/Http/Controllers/ForgotPasswordController.php
+++ b/app/Http/Controllers/ForgotPasswordController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Mail\PasswordResetMail;
+use App\Models\Metin2User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+class ForgotPasswordController extends Controller
+{
+    public function showLinkRequestForm()
+    {
+        return view('auth.forgot-password', [
+            'title' => ' - '.__('messages.forgot_password_title'),
+        ]);
+    }
+
+    public function sendResetLinkEmail(Request $request)
+    {
+        $request->validate(['email' => 'required|email']);
+
+        $user = Metin2User::where('email', $request->email)->first();
+        if (!$user) {
+            return back()->withErrors(['email' => __('messages.password_reset_link_invalid')]);
+        }
+
+        $token = Str::random(64);
+        DB::table('password_reset_tokens')->updateOrInsert(
+            ['email' => $user->email],
+            [
+                'token' => Hash::make($token),
+                'created_at' => now(),
+            ]
+        );
+
+        $resetLink = route('password.reset.form', ['token' => $token, 'email' => $user->email]);
+        $cancelLink = route('password.reset.cancel', ['token' => $token, 'email' => $user->email]);
+
+        Mail::to($user->email)->send(new PasswordResetMail($user->login, $resetLink, $cancelLink));
+
+        return back()->with('status', __('messages.password_reset_link_sent'));
+    }
+
+    public function showResetForm(string $token)
+    {
+        return view('auth.reset-password', [
+            'title' => ' - '.__('messages.reset_password_title'),
+            'token' => $token,
+        ]);
+    }
+
+    public function reset(Request $request)
+    {
+        $request->validate([
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => 'required|confirmed|min:6',
+        ]);
+
+        $record = DB::table('password_reset_tokens')->where('email', $request->email)->first();
+        if (!$record || !Hash::check($request->token, $record->token)) {
+            return back()->withErrors(['email' => __('messages.password_reset_link_invalid')]);
+        }
+
+        $hashedPassword = '*' . strtoupper(sha1(sha1($request->password, true)));
+        DB::connection('account')->table('account')->where('email', $request->email)->update(['password' => $hashedPassword]);
+
+        DB::table('password_reset_tokens')->where('email', $request->email)->delete();
+
+        return redirect()->route('metin2.login')->with('success', __('messages.password_reset_success'));
+    }
+
+    public function cancel(Request $request, string $token)
+    {
+        $email = $request->query('email');
+        $record = DB::table('password_reset_tokens')->where('email', $email)->first();
+        if ($record && Hash::check($token, $record->token)) {
+            DB::table('password_reset_tokens')->where('email', $email)->delete();
+        }
+
+        return redirect('/')->with('status', __('messages.cancel_reset'));
+    }
+}

--- a/app/Mail/PasswordResetMail.php
+++ b/app/Mail/PasswordResetMail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public string $username;
+    public string $reset_link;
+    public string $cancel_link;
+
+    public function __construct(string $username, string $reset_link, string $cancel_link)
+    {
+        $this->username = $username;
+        $this->reset_link = $reset_link;
+        $this->cancel_link = $cancel_link;
+    }
+
+    public function build()
+    {
+        return $this->subject(__('messages.password_reset_email_subject'))
+            ->view('emails.password_reset')
+            ->with([
+                'username' => $this->username,
+                'reset_link' => $this->reset_link,
+                'cancel_link' => $this->cancel_link,
+            ]);
+    }
+}

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -140,5 +140,23 @@ return [
     'error_current_password' => 'The current password is incorrect.',
     'error_password_mismatch' => 'New passwords do not match.',
 
+    // PASSWORD RESET
+    'forgot_password_title' => 'Forgot Password',
+    'reset_password_title' => 'Reset Password',
+    'send_reset_link' => 'Send Reset Link',
+    'password_reset_link_sent' => 'We have emailed your password reset link!',
+    'password_reset_link_invalid' => 'No user found with that email.',
+    'reset_password' => 'Reset Password',
+    'cancel_reset' => 'Cancel Password Reset',
+    'password_reset_success' => 'Your password has been reset successfully.',
+    'password_reset_email_subject' => 'Password Reset Request',
+    'password_reset_email_greeting' => 'Hello, :username',
+    'password_reset_email_line1' => 'You are receiving this email because we received a password reset request for your account.',
+    'password_reset_email_line2' => 'Click the button below to reset your password:',
+    'password_reset_email_cancel' => 'If you did not request a password reset, click here:',
+    'password_reset_email_button' => 'Reset Password',
+    'password_reset_email_cancel_button' => 'Cancel Request',
+    'password_reset_email_disregard' => 'If you did not request a password reset, no further action is required.',
+
 ];
 

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -139,5 +139,23 @@ return [
     'password_updated' => 'Parola ta a fost schimbată cu succes!',
     'error_current_password' => 'Parola curentă este incorectă.',
     'error_password_mismatch' => 'Parolele noi nu se potrivesc.',
+
+    // RESETARE PAROLA
+    'forgot_password_title' => 'Recuperare Parolă',
+    'reset_password_title' => 'Resetează Parola',
+    'send_reset_link' => 'Trimite linkul de resetare',
+    'password_reset_link_sent' => 'Ți-am trimis un email cu linkul de resetare!',
+    'password_reset_link_invalid' => 'Nu există niciun utilizator cu acest email.',
+    'reset_password' => 'Resetează Parola',
+    'cancel_reset' => 'Anulează Resetarea',
+    'password_reset_success' => 'Parola ta a fost resetată cu succes.',
+    'password_reset_email_subject' => 'Solicitare Resetare Parolă',
+    'password_reset_email_greeting' => 'Salut, :username',
+    'password_reset_email_line1' => 'Ai primit acest email deoarece s-a solicitat o resetare a parolei contului tău.',
+    'password_reset_email_line2' => 'Apasă pe butonul de mai jos pentru a-ți reseta parola:',
+    'password_reset_email_cancel' => 'Dacă nu ai solicitat resetarea parolei, apasă aici:',
+    'password_reset_email_button' => 'Resetează Parola',
+    'password_reset_email_cancel_button' => 'Anulează cererea',
+    'password_reset_email_disregard' => 'Dacă nu ai solicitat resetarea parolei, ignoră acest email.',
     
 ];

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,0 +1,30 @@
+@extends('layout')
+@section('title', __('messages.forgot_password_title'))
+
+@section('content')
+<main class="content py-12 px-4">
+    <div class="form-container p-8 md:p-10 rounded-xl shadow-2xl w-full max-w-xl mx-auto mt-6 bg-gray-900 border border-green-700">
+        <h2 class="text-3xl font-bold mb-6 text-green-400 text-center">{{ __('messages.forgot_password_title') }}</h2>
+        @if (session('status'))
+            <div class="bg-green-900/30 text-green-400 p-4 rounded-lg mb-6">{{ session('status') }}</div>
+        @endif
+        @if ($errors->any())
+            <div class="bg-red-900/30 text-red-400 p-4 rounded-lg mb-6">
+                <ul class="list-disc pl-4">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+        <form method="POST" action="{{ route('password.email') }}">
+            @csrf
+            <div class="mb-4">
+                <label class="block text-gray-300 mb-2">Email</label>
+                <input type="email" name="email" class="w-full bg-gray-800 border border-gray-600 p-2 rounded" required>
+            </div>
+            <button type="submit" class="w-full bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600">{{ __('messages.send_reset_link') }}</button>
+        </form>
+    </div>
+</main>
+@endsection

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,0 +1,33 @@
+@extends('layout')
+@section('title', __('messages.reset_password_title'))
+
+@section('content')
+<main class="content py-12 px-4">
+    <div class="form-container p-8 md:p-10 rounded-xl shadow-2xl w-full max-w-xl mx-auto mt-6 bg-gray-900 border border-green-700">
+        <h2 class="text-3xl font-bold mb-6 text-green-400 text-center">{{ __('messages.reset_password_title') }}</h2>
+        @if ($errors->any())
+            <div class="bg-red-900/30 text-red-400 p-4 rounded-lg mb-6">
+                <ul class="list-disc pl-4">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+        <form method="POST" action="{{ route('password.update.reset') }}">
+            @csrf
+            <input type="hidden" name="token" value="{{ $token }}">
+            <input type="hidden" name="email" value="{{ request('email') }}">
+            <div class="mb-4">
+                <label class="block text-gray-300 mb-2">{{ __('messages.new_password') }}</label>
+                <input type="password" name="password" class="w-full bg-gray-800 border border-gray-600 p-2 rounded" required>
+            </div>
+            <div class="mb-4">
+                <label class="block text-gray-300 mb-2">{{ __('messages.confirm_new_password') }}</label>
+                <input type="password" name="password_confirmation" class="w-full bg-gray-800 border border-gray-600 p-2 rounded" required>
+            </div>
+            <button type="submit" class="w-full bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600">{{ __('messages.reset_password') }}</button>
+        </form>
+    </div>
+</main>
+@endsection

--- a/resources/views/emails/password_reset.blade.php
+++ b/resources/views/emails/password_reset.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ __('messages.password_reset_email_subject') }}</title>
+</head>
+<body>
+    <h2>{{ __('messages.password_reset_email_greeting', ['username' => $username]) }}</h2>
+    <p>{{ __('messages.password_reset_email_line1') }}</p>
+    <p>{{ __('messages.password_reset_email_line2') }}</p>
+    <a href="{{ $reset_link }}" style="display:inline-block;padding:10px 20px;color:white;background:#3490dc;text-decoration:none;">{{ __('messages.password_reset_email_button') }}</a>
+    <p>{{ __('messages.password_reset_email_cancel') }}</p>
+    <a href="{{ $cancel_link }}" style="display:inline-block;padding:10px 20px;color:white;background:#e53e3e;text-decoration:none;">{{ __('messages.password_reset_email_cancel_button') }}</a>
+    <p>{{ __('messages.password_reset_email_disregard', [], 'en') }}</p>
+</body>
+</html>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -438,6 +438,9 @@
                                         {{ __('messages.menu_register') }}
                                     </a>
                                 </div>
+                                <div class="text-center mt-2">
+                                    <a href="{{ route('password.request') }}" class="text-sm text-gray-400 hover:underline">{{ __('messages.sidebar_right_forgot_password') }}</a>
+                                </div>
                             </form>
                         </div>
                     </div>

--- a/resources/views/livewire/auth/metin2-login.blade.php
+++ b/resources/views/livewire/auth/metin2-login.blade.php
@@ -31,6 +31,9 @@
             <button type="submit" class="w-full bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600 transition">
                 {{ __('messages.sidebar_right_login_button') }}
             </button>
+            <div class="text-center mt-2">
+                <a href="{{ route('password.request') }}" class="text-sm text-gray-400 hover:underline">{{ __('messages.sidebar_right_forgot_password') }}</a>
+            </div>
         </form>
 
         <div class="mt-4 text-center text-sm text-gray-400">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\ItemShopController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\NewsController;
 use App\Http\Controllers\GalleryController;
+use App\Http\Controllers\ForgotPasswordController;
 
 // Aplica middleware-ul global pentru toate rutele
 Route::middleware([LanguageMiddleware::class])->group(function () {
@@ -47,6 +48,13 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
         Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
         Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
         Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
+
+        // Password reset routes
+        Route::get('/forgot-password', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
+        Route::post('/forgot-password', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
+        Route::get('/reset-password/{token}', [ForgotPasswordController::class, 'showResetForm'])->name('password.reset.form');
+        Route::post('/reset-password', [ForgotPasswordController::class, 'reset'])->name('password.update.reset');
+        Route::get('/cancel-reset/{token}', [ForgotPasswordController::class, 'cancel'])->name('password.reset.cancel');
 	
 	Route::post('/metin2/login', [Metin2AuthController::class, 'login'])->name('metin2.login');
 	Route::post('/metin2/logout', [Metin2AuthController::class, 'logout'])->name('metin2.logout');


### PR DESCRIPTION
## Summary
- add password reset controller
- send email with reset and cancel links
- create pages and emails for password reset
- show link on login forms
- add translations and routes

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685074066160832cb9b430be08c85813