### PR TITLE
Add translation for unauthenticated message

### DIFF
--- a/app/Http/Middleware/Metin2AuthMiddleware.php
+++ b/app/Http/Middleware/Metin2AuthMiddleware.php
@@ -14,7 +14,7 @@ class Metin2AuthMiddleware
     public function handle(Request $request, Closure $next)
     {
         if (!Auth::guard('metin2')->check()) {
-            return redirect()->route('index')->with('error', 'Trebuie să fii autentificat pentru a accesa această pagină.');
+            return redirect()->route('index')->with('error', __('messages.error_not_authenticated'));
         }
 
         return $next($request);

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -31,6 +31,7 @@ return [
     'auth_password_invalid' => 'Password is incorrect.',
     'auth_success' => 'You have successfully logged in.',
     'auth_logout' => 'You have been logged out successfully.',
+    'error_not_authenticated' => 'You must be authenticated to access this page.',
 
     // Sidebar Right - Logged In
     'sidebar_right_welcome' => 'Welcome,',

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -31,6 +31,7 @@ return [
     'auth_password_invalid' => 'Parola este incorectă.',
     'auth_success' => 'Te-ai autentificat cu succes.',
     'auth_logout' => 'Te-ai deconectat cu succes.',
+    'error_not_authenticated' => 'Trebuie să fii autentificat pentru a accesa această pagină.',
 
     // Sidebar Right - Logged In
     'sidebar_right_welcome' => 'Bine ai venit,',


### PR DESCRIPTION
## Summary
- add new `error_not_authenticated` translation key
- reference translation in `Metin2AuthMiddleware`

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851616a228c832cb07fe51313527d0c