### PR TITLE
Add composer test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ The application includes the following functionality:
 4. Run `php artisan migrate`.
 5. Start the development server using `php artisan serve`.
 
+## Testing
+
+Run the test suite with:
+
+```bash
+composer test
+```
+
+

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
-        ]
+        ],
+        "test": "phpunit"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
## Summary
- add a `test` script in `composer.json`
- document how to run tests in README

## Testing
- `composer test` *(fails: Invalid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68516187bd44832cb6a84d0a83c56d7e