### PR TITLE
Add news categories support

### DIFF
--- a/app/Filament/Resources/NewsCategoryResource.php
+++ b/app/Filament/Resources/NewsCategoryResource.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\NewsCategoryResource\Pages;
+use App\Models\NewsCategory;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Forms\Components\TextInput;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Forms\Components\Section;
+
+class NewsCategoryResource extends Resource
+{
+    protected static ?string $model = NewsCategory::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
+
+    protected static ?string $navigationGroup = 'Content Management';
+
+    public static function form(Forms\Form $form): Forms\Form
+    {
+        return $form->schema([
+            Section::make('Category Details')->schema([
+                TextInput::make('name')
+                    ->required()
+                    ->unique()
+                    ->placeholder('Enter category name'),
+
+                TextInput::make('slug')
+                    ->disabled()
+                    ->unique(),
+
+                TextInput::make('icon')
+                    ->placeholder('Ex: \u{1F4F0}'),
+            ])
+        ]);
+    }
+
+    public static function table(Tables\Table $table): Tables\Table
+    {
+        return $table->columns([
+            TextColumn::make('name')->sortable()->searchable(),
+            TextColumn::make('slug')->sortable(),
+            TextColumn::make('icon')->label('Icon')->sortable(),
+            TextColumn::make('created_at')->dateTime()->sortable(),
+        ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListNewsCategories::route('/'),
+            'create' => Pages\CreateNewsCategory::route('/create'),
+            'edit' => Pages\EditNewsCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/NewsCategoryResource/Pages/CreateNewsCategory.php
+++ b/app/Filament/Resources/NewsCategoryResource/Pages/CreateNewsCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\NewsCategoryResource\Pages;
+
+use App\Filament\Resources\NewsCategoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateNewsCategory extends CreateRecord
+{
+    protected static string $resource = NewsCategoryResource::class;
+}

--- a/app/Filament/Resources/NewsCategoryResource/Pages/EditNewsCategory.php
+++ b/app/Filament/Resources/NewsCategoryResource/Pages/EditNewsCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\NewsCategoryResource\Pages;
+
+use App\Filament\Resources\NewsCategoryResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditNewsCategory extends EditRecord
+{
+    protected static string $resource = NewsCategoryResource::class;
+}

--- a/app/Filament/Resources/NewsCategoryResource/Pages/ListNewsCategories.php
+++ b/app/Filament/Resources/NewsCategoryResource/Pages/ListNewsCategories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\NewsCategoryResource\Pages;
+
+use App\Filament\Resources\NewsCategoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListNewsCategories extends ListRecords
+{
+    protected static string $resource = NewsCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/NewsResource.php
+++ b/app/Filament/Resources/NewsResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\NewsResource\Pages;
 use App\Models\News;
+use App\Models\NewsCategory;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -11,6 +12,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
 use Filament\Tables\Columns\TextColumn;
 
 class NewsResource extends Resource
@@ -26,6 +28,10 @@ class NewsResource extends Resource
                 TextInput::make('title')
                     ->required()
                     ->maxLength(255),
+                Forms\Components\Select::make('news_category_id')
+                    ->label('Category')
+                    ->relationship('category', 'name')
+                    ->required(),
                 RichEditor::make('content')
                     ->required(),
             ]);
@@ -36,6 +42,7 @@ class NewsResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('title')->sortable()->searchable(),
+                TextColumn::make('category.name')->label('Category')->sortable(),
                 TextColumn::make('created_at')->dateTime()->sortable()->label('Created'),
             ])
             ->actions([

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -5,12 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use App\Models\NewsCategory;
 
 class News extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'slug', 'content'];
+    protected $fillable = ['title', 'slug', 'content', 'news_category_id'];
 
     protected static function boot()
     {
@@ -23,5 +24,10 @@ class News extends Model
     public function comments()
     {
         return $this->hasMany(Comment::class);
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(NewsCategory::class, 'news_category_id');
     }
 }

--- a/app/Models/NewsCategory.php
+++ b/app/Models/NewsCategory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class NewsCategory extends Model
+{
+    protected $fillable = ['name', 'slug', 'icon'];
+
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($category) {
+            $category->slug = Str::slug($category->name);
+        });
+    }
+
+    public function news()
+    {
+        return $this->hasMany(News::class, 'news_category_id');
+    }
+}

--- a/database/migrations/2025_07_01_000000_create_news_categories_table.php
+++ b/database/migrations/2025_07_01_000000_create_news_categories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('news_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('slug')->unique();
+            $table->string('icon')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('news_categories');
+    }
+};

--- a/database/migrations/2025_07_01_000001_add_news_category_id_to_news_table.php
+++ b/database/migrations/2025_07_01_000001_add_news_category_id_to_news_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->foreignId('news_category_id')
+                ->nullable()
+                ->constrained('news_categories')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('news_category_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add `NewsCategory` model and Filament resource
- create migrations for news category management
- link News items to categories via new foreign key
- update News Filament resource to pick category

## Testing
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856903f527c832ca44054ba9825120e