### PR TITLE
Add create action to News resource list

### DIFF
--- a/app/Filament/Resources/NewsResource/Pages/ListNews.php
+++ b/app/Filament/Resources/NewsResource/Pages/ListNews.php
@@ -9,4 +9,11 @@ use Filament\Resources\Pages\ListRecords;
 class ListNews extends ListRecords
 {
     protected static string $resource = NewsResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- show create button in News list page by implementing `getHeaderActions`

## Testing
- `composer test` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685692ca2c90832c895e81f6063aaac1