### PR TITLE
Restrict news comments to logged in users

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\News;
 use App\Models\Comment;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class NewsController extends Controller
 {
@@ -23,6 +24,10 @@ class NewsController extends Controller
 
     public function comment(Request $request, $slug)
     {
+        if (!Auth::guard('metin2')->check()) {
+            return redirect()->back()->with('error', __('messages.error_not_authenticated'));
+        }
+
         $request->validate([
             'content' => 'required|string',
         ]);
@@ -30,7 +35,7 @@ class NewsController extends Controller
         $news = News::where('slug', $slug)->firstOrFail();
 
         $news->comments()->create([
-            'author' => $request->input('author'),
+            'author' => Auth::guard('metin2')->user()->login,
             'content' => $request->input('content'),
         ]);
 

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -13,12 +13,15 @@
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
     <h3 class="text-lg font-semibold mb-4 text-green-400">Comments</h3>
 
-    <form action="{{ route('news.comment', $news->slug) }}" method="POST" class="mb-4">
-        @csrf
-        <input type="text" name="author" placeholder="Your name" class="w-full mb-2 p-2 bg-gray-800 text-white rounded" />
-        <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
-        <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">Submit</button>
-    </form>
+    @if(Auth::guard('metin2')->check())
+        <form action="{{ route('news.comment', $news->slug) }}" method="POST" class="mb-4">
+            @csrf
+            <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+            <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">Submit</button>
+        </form>
+    @else
+        <p class="mb-4 text-red-500">{{ __('messages.error_not_authenticated') }}</p>
+    @endif
 
     <div class="space-y-4">
         @foreach ($comments as $comment)


### PR DESCRIPTION
## Summary
- require authentication in `NewsController@comment`
- hide news comment form for guests

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685693c15438832c8c50d63ca0167258