### PR TITLE
Show disabled comment fields for guests

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -165,5 +165,8 @@ return [
     'password_reset_email_cancel_button' => 'Cancel Request',
     'password_reset_email_disregard' => 'If you did not request a password reset, no further action is required.',
 
+    // Comments
+    'news_comment_login_required' => 'You must login to comment.',
+
 ];
 

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -164,5 +164,8 @@ return [
     'password_reset_email_button' => 'Resetează Parola',
     'password_reset_email_cancel_button' => 'Anulează cererea',
     'password_reset_email_disregard' => 'Dacă nu ai solicitat resetarea parolei, ignoră acest email.',
-    
+
+    // Comentarii
+    'news_comment_login_required' => 'Trebuie să te autentifici pentru a comenta.',
+
 ];

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -20,7 +20,16 @@
             <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">Submit</button>
         </form>
     @else
-        <p class="mb-4 text-red-500">{{ __('messages.error_not_authenticated') }}</p>
+        <div class="relative mb-4">
+            <form class="pointer-events-none opacity-50 space-y-2">
+                <input type="text" value="Unknown" class="w-full p-2 bg-gray-800 text-white rounded" disabled />
+                <textarea class="w-full p-2 bg-gray-800 text-white rounded" disabled></textarea>
+                <button class="px-4 py-2 bg-gray-600 text-white rounded" disabled>Submit</button>
+            </form>
+            <div class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-60 rounded">
+                <p class="text-red-500">{{ __('messages.news_comment_login_required') }}</p>
+            </div>
+        </div>
     @endif
 
     <div class="space-y-4">


### PR DESCRIPTION
## Summary
- add translation for guest comment restriction
- show disabled comment form when user is not authenticated
- overlay disabled form with login notice

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68569534150c832c97e03b135f54cd63