### PR TITLE
Fix events timestamp casting

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -9,5 +9,15 @@ class Event extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'description', 'start_date', 'end_date'];
+    protected $fillable = [
+        'title',
+        'description',
+        'start_date',
+        'end_date',
+    ];
+
+    protected $casts = [
+        'start_date' => 'datetime',
+        'end_date' => 'datetime',
+    ];
 }


### PR DESCRIPTION
## Summary
- cast `start_date` and `end_date` as `datetime`

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68569823cf48832c885301c241fa7796