### PR TITLE
Show metadata on news posts

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -11,13 +11,14 @@ class NewsController extends Controller
 {
     public function index()
     {
-        $news = News::latest()->paginate(10);
+        $news = News::withCount('comments')->latest()->paginate(10);
         return view('news.index', compact('news'));
     }
 
     public function show($slug)
     {
         $news = News::where('slug', $slug)->firstOrFail();
+        $news->increment('views');
         $comments = $news->comments()->latest()->get();
         return view('news.show', compact('news', 'comments'));
     }

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -10,7 +10,7 @@ class WelcomeController extends Controller
 {
     public function index()
     {
-        $latestNews = News::latest()->take(3)->get();
+        $latestNews = News::withCount('comments')->latest()->take(3)->get();
         $latestMedia = GalleryItem::latest()->take(4)->get();
         return view('welcome', compact('latestNews', 'latestMedia'));
     }

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -11,7 +11,7 @@ class News extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'slug', 'content', 'news_category_id'];
+    protected $fillable = ['title', 'slug', 'content', 'news_category_id', 'author', 'views'];
 
     protected static function boot()
     {

--- a/database/migrations/2025_09_01_000002_add_author_and_views_to_news_table.php
+++ b/database/migrations/2025_09_01_000002_add_author_and_views_to_news_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->string('author')->nullable();
+            $table->unsignedBigInteger('views')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->dropColumn(['author', 'views']);
+        });
+    }
+};

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -10,6 +10,12 @@
         @foreach ($news as $post)
             <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
                 <h3 class="font-bold text-yellow-400 text-lg">{{ $post->title }}</h3>
+                <div class="text-xs text-gray-400 mb-1">
+                    @if($post->author)
+                        {{ __('By') }} {{ $post->author }} ·
+                    @endif
+                    {{ $post->created_at->format('M d, Y') }} · {{ $post->views }} views · {{ $post->comments_count }} comments
+                </div>
                 <p class="text-gray-300 text-sm mt-2">{{ Str::limit(strip_tags($post->content), 150) }}</p>
                 <a href="{{ route('news.show', $post->slug) }}" class="inline-block mt-2 text-xs text-green-400 hover:text-green-300">Read More →</a>
             </div>

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -4,7 +4,13 @@
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
-    <h2 class="text-2xl font-bold mb-4 text-green-400">{{ $news->title }}</h2>
+    <h2 class="text-2xl font-bold mb-1 text-green-400">{{ $news->title }}</h2>
+    <div class="text-xs text-gray-400 mb-4">
+        @if($news->author)
+            {{ __('By') }} {{ $news->author }} ·
+        @endif
+        {{ $news->created_at->format('M d, Y') }} · {{ $news->views }} views · {{ $comments->count() }} comments
+    </div>
     <div class="prose prose-invert">
         {!! $news->content !!}
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -65,6 +65,12 @@
         @foreach($latestNews as $post)
             <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700 hover:border-green-500 transition-all duration-300 transform hover:scale-[1.01]">
                 <h3 class="font-bold text-yellow-400">{{ $post->title }}</h3>
+                <div class="text-xs text-gray-400 mb-1">
+                    @if($post->author)
+                        {{ __('By') }} {{ $post->author }} ·
+                    @endif
+                    {{ $post->created_at->format('M d, Y') }} · {{ $post->views }} views · {{ $post->comments_count }} comments
+                </div>
                 <p class="text-gray-300 text-sm">{{ Str::limit(strip_tags($post->content), 150) }}</p>
                 <a href="{{ route('news.show', $post->slug) }}" class="inline-block mt-2 text-xs text-green-400 hover:text-green-300 transition">{{ __('Read More') }} →</a>
             </div>


### PR DESCRIPTION
## Summary
- track news author and view counts
- show comment counts
- display the new metadata on the home page and news section
- increment view counts when a post is read

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6856980177e8832cb75edfd60a9b771b