### PR TITLE
Add calendar to events page

### DIFF
--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -10,10 +10,36 @@
                 <h3 class="font-bold text-yellow-400 text-lg">{{ $event->title }}</h3>
                 <p class="text-gray-300 text-sm">{{ $event->start_date->format('Y-m-d H:i') }}</p>
                 @if($event->description)
-                    <p class="mt-2 text-gray-300">{!! nl2br(e($event->description)) !!}</p>
+                    <div class="mt-2 text-gray-300 prose prose-invert max-w-none">
+                        {!! $event->description !!}
+                    </div>
                 @endif
             </li>
         @endforeach
     </ul>
 </div>
+
+<div id="calendar" class="mt-6 bg-black bg-opacity-50 p-4 rounded-lg border border-gray-700"></div>
+
+@php
+    $calendarEvents = $events->map(fn($event) => [
+        'title' => $event->title,
+        'start' => $event->start_date->format('Y-m-d'),
+        'end' => optional($event->end_date)->format('Y-m-d'),
+    ]);
+@endphp
+
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.5/index.global.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.5/index.global.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var calendarEl = document.getElementById('calendar');
+        var calendar = new FullCalendar.Calendar(calendarEl, {
+            initialView: 'dayGridMonth',
+            events: @json($calendarEvents),
+            height: 'auto'
+        });
+        calendar.render();
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- render HTML in event descriptions
- display events on a calendar using FullCalendar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685698c88f6c832cb488eaa6c17c4c0c