### PR TITLE
Enhance event calendar UI

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -166,3 +166,28 @@ body::before {
 ::-webkit-scrollbar-thumb:hover {
     background: var(--secondary-accent);
 }
+
+/* FullCalendar Custom Styles */
+.fc {
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid #374151;
+    color: #f3f4f6;
+}
+
+.fc-toolbar-title {
+    color: #f3f4f6;
+}
+
+.fc-daygrid-day-number {
+    color: #a3e635;
+}
+
+.fc-event {
+    background-color: var(--accent-color);
+    border: none;
+    cursor: pointer;
+}
+
+.fc-daygrid-event-dot {
+    border-color: var(--accent-color);
+}

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -21,11 +21,26 @@
 
 <div id="calendar" class="mt-6 bg-black bg-opacity-50 p-4 rounded-lg border border-gray-700"></div>
 
+<!-- Event Modal -->
+<div id="event-modal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-80 hidden z-50" role="dialog" aria-modal="true" aria-labelledby="event-modal-title">
+    <div class="glassmorphism max-w-lg w-full rounded-xl border border-green-500 p-6">
+        <div class="flex justify-between items-start mb-4">
+            <h3 id="event-modal-title" class="text-xl font-semibold text-yellow-300"></h3>
+            <button id="close-event-modal" class="text-gray-400 hover:text-red-400 text-2xl leading-none">&times;</button>
+        </div>
+        <p id="event-modal-date" class="text-sm text-gray-300 mb-4"></p>
+        <div id="event-modal-description" class="text-gray-300 prose prose-invert max-w-none"></div>
+    </div>
+</div>
+
 @php
     $calendarEvents = $events->map(fn($event) => [
+        'id' => $event->id,
         'title' => $event->title,
         'start' => $event->start_date->format('Y-m-d'),
         'end' => optional($event->end_date)->format('Y-m-d'),
+        'description' => $event->description,
+        'color' => '#34d399',
     ]);
 @endphp
 
@@ -34,12 +49,45 @@
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         var calendarEl = document.getElementById('calendar');
+        var modal = document.getElementById('event-modal');
+        var closeModalBtn = document.getElementById('close-event-modal');
+
         var calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: 'dayGridMonth',
+            eventDisplay: 'block',
             events: @json($calendarEvents),
-            height: 'auto'
+            height: 'auto',
+            eventClick: function(info) {
+                info.jsEvent.preventDefault();
+                document.getElementById('event-modal-title').textContent = info.event.title;
+                var start = info.event.start;
+                var end = info.event.end;
+                var options = { year: 'numeric', month: 'long', day: 'numeric' };
+                var dateText = start.toLocaleDateString(undefined, options);
+                if (end) {
+                    var endText = new Date(end.getTime() - 1).toLocaleDateString(undefined, options);
+                    dateText += ' - ' + endText;
+                }
+                document.getElementById('event-modal-date').textContent = dateText;
+                document.getElementById('event-modal-description').innerHTML = info.event.extendedProps.description || '';
+                modal.classList.remove('hidden');
+                document.body.classList.add('overflow-hidden');
+            }
         });
         calendar.render();
+
+        var closeModal = function() {
+            modal.classList.add('hidden');
+            document.body.classList.remove('overflow-hidden');
+        };
+        if (closeModalBtn) {
+            closeModalBtn.addEventListener('click', closeModal);
+        }
+        modal.addEventListener('click', function(e) {
+            if (e.target === modal) {
+                closeModal();
+            }
+        });
     });
 </script>
 @endsection


### PR DESCRIPTION
## Summary
- display events in calendar blocks
- add modal popup for event details
- style FullCalendar to match theme

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: missing script)*
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569a3eb7b8832c9d3894ea2e03394d