### PR TITLE
Add news category and author filtering

### DIFF
--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -1,10 +1,10 @@
 @extends('layout')
 
-@section('title', 'News')
+@section('title', $pageTitle ?? 'News')
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
-    <h2 class="text-xl font-semibold mb-4 text-green-400">Latest News & Events</h2>
+    <h2 class="text-xl font-semibold mb-4 text-green-400">{{ $heading ?? 'Latest News & Events' }}</h2>
 
     <div class="space-y-4">
         @foreach ($news as $post)
@@ -12,7 +12,10 @@
                 <h3 class="font-bold text-yellow-400 text-lg">{{ $post->title }}</h3>
                 <div class="text-xs text-gray-400 mb-1">
                     @if($post->author)
-                        {{ __('By') }} {{ $post->author }} ·
+                        {{ __('Posted by:') }} <a href="{{ route('news.author', ['author' => $post->author]) }}" class="hover:underline">{{ $post->author }}</a> ·
+                    @endif
+                    @if($post->category)
+                        <a href="{{ route('news.category', $post->category->slug) }}" class="hover:underline">{{ $post->category->name }}</a> ·
                     @endif
                     {{ $post->created_at->format('M d, Y') }} · {{ $post->views }} views · {{ $post->comments_count }} comments
                 </div>

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -7,7 +7,10 @@
     <h2 class="text-2xl font-bold mb-1 text-green-400">{{ $news->title }}</h2>
     <div class="text-xs text-gray-400 mb-4">
         @if($news->author)
-            {{ __('By') }} {{ $news->author }} ·
+            {{ __('Posted by:') }} <a href="{{ route('news.author', ['author' => $news->author]) }}" class="hover:underline">{{ $news->author }}</a> ·
+        @endif
+        @if($news->category)
+            <a href="{{ route('news.category', $news->category->slug) }}" class="hover:underline">{{ $news->category->name }}</a> ·
         @endif
         {{ $news->created_at->format('M d, Y') }} · {{ $news->views }} views · {{ $comments->count() }} comments
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,8 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
 
         // News routes
         Route::get('/news', [NewsController::class, 'index'])->name('news.index');
+        Route::get('/news/category/{slug}', [NewsController::class, 'category'])->name('news.category');
+        Route::get('/news/author/{author}', [NewsController::class, 'author'])->name('news.author');
         Route::get('/news/{slug}', [NewsController::class, 'show'])->name('news.show');
         Route::post('/news/{slug}/comment', [NewsController::class, 'comment'])->name('news.comment');
         Route::post('/comments/{comment}/like', [NewsController::class, 'like'])->name('comments.like');


### PR DESCRIPTION
## Summary
- show author and category on news posts
- allow filtering news by author or category
- add dynamic headings for filtered views

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68569a722978832cbaa61f4b9a89a17a