### PR TITLE
Fix MySQL style password hashing

### DIFF
--- a/app/Http/Controllers/ForgotPasswordController.php
+++ b/app/Http/Controllers/ForgotPasswordController.php
@@ -66,7 +66,7 @@ class ForgotPasswordController extends Controller
             return back()->withErrors(['email' => __('messages.password_reset_link_invalid')]);
         }
 
-        $hashedPassword = '*' . strtoupper(sha1(sha1($request->password, true)));
+        $hashedPassword = \App\Support\MySQLPassword::hash($request->password);
         DB::connection('account')->table('account')->where('email', $request->email)->update(['password' => $hashedPassword]);
 
         DB::table('password_reset_tokens')->where('email', $request->email)->delete();

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -40,7 +40,7 @@ class PasswordController extends Controller
         }
     
         // 🔹 4. Verificăm parola actuală folosind SHA1(SHA1(password)) și adăugăm "*"
-        $hashedInputPassword = '*' . strtoupper(sha1(sha1($request->current_password, true)));
+        $hashedInputPassword = \App\Support\MySQLPassword::hash($request->current_password);
     
         if ($hashedInputPassword !== strtoupper($user->password)) {
             throw ValidationException::withMessages([
@@ -49,7 +49,7 @@ class PasswordController extends Controller
         }
     
         // 🔹 5. Aplicăm același hashing SHA1(SHA1(new_password)) și adăugăm "*"
-        $newHashedPassword = '*' . strtoupper(sha1(sha1($request->new_password, true)));
+        $newHashedPassword = \App\Support\MySQLPassword::hash($request->new_password);
     
         // 🔹 6. Schimbăm parola în baza de date
         \DB::connection('account')->table('account')

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use App\Models\Account;
 use App\Mail\AccountActivationMail;
@@ -79,8 +78,8 @@ class RegisterController extends Controller
             // Setăm statusul contului
             $accountStatus = $requireEmailVerification ? 'PENDING' : 'OK';
 
-            // Inserare cont folosind hashing modern
-            $hashedPassword = Hash::make($request->password);
+            // Inserare cont folosind hashing compatibil Metin2
+            $hashedPassword = \App\Support\MySQLPassword::hash($request->password);
 
             $accountId = DB::connection('account')->table('account')->insertGetId([
                 'login' => $request->username,

--- a/app/Livewire/Auth/Metin2Login.php
+++ b/app/Livewire/Auth/Metin2Login.php
@@ -3,7 +3,6 @@
 namespace App\Livewire\Auth;
 
 use Livewire\Component;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Hash;
 use App\Models\Metin2User;
@@ -38,19 +37,10 @@ class Metin2Login extends Component
             return;
         }
 
-        $validPassword = Hash::check($this->password, $user->password);
-
-        if (!$validPassword) {
-            $passwordCheck = DB::connection('account')
-                ->selectOne("SELECT PASSWORD(?) as hashed", [$this->password]);
-
-            if ($passwordCheck && $passwordCheck->hashed === $user->password) {
-                $validPassword = true;
-                $newHash = Hash::make($this->password);
-                DB::connection('account')->table('account')->where('id', $user->id)
-                    ->update(['password' => $newHash]);
-                $user->password = $newHash;
-            }
+        if (str_starts_with($user->password, '*')) {
+            $validPassword = \App\Support\MySQLPassword::check($this->password, $user->password);
+        } else {
+            $validPassword = Hash::check($this->password, $user->password);
         }
 
         if (!$validPassword) {

--- a/app/Support/MySQLPassword.php
+++ b/app/Support/MySQLPassword.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support;
+
+class MySQLPassword
+{
+    public static function hash(string $password): string
+    {
+        return '*' . strtoupper(sha1(sha1($password, true)));
+    }
+
+    public static function check(string $password, string $hashed): bool
+    {
+        return hash_equals(strtoupper($hashed), self::hash($password));
+    }
+}


### PR DESCRIPTION
## Summary
- support Metin2 password hashes
- update registration and password reset
- keep compatibility with existing bcrypt passwords

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569c192524832cbc597a563d29871c