### PR TITLE
Add SEO management via Filament

### DIFF
--- a/app/Filament/Resources/SeoMetaResource.php
+++ b/app/Filament/Resources/SeoMetaResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SeoMetaResource\Pages;
+use App\Models\SeoMeta;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Tables\Columns\TextColumn;
+
+class SeoMetaResource extends Resource
+{
+    protected static ?string $model = SeoMeta::class;
+    protected static ?string $navigationIcon = 'heroicon-o-globe-alt';
+    protected static ?string $navigationGroup = 'Settings';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('page')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                TextInput::make('title')
+                    ->maxLength(255),
+                Textarea::make('description')
+                    ->rows(3),
+                Textarea::make('keywords')
+                    ->rows(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('page')->sortable()->searchable(),
+                TextColumn::make('title')->limit(50),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSeoMeta::route('/'),
+            'create' => Pages\CreateSeoMeta::route('/create'),
+            'edit' => Pages\EditSeoMeta::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SeoMetaResource/Pages/CreateSeoMeta.php
+++ b/app/Filament/Resources/SeoMetaResource/Pages/CreateSeoMeta.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SeoMetaResource\Pages;
+
+use App\Filament\Resources\SeoMetaResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSeoMeta extends CreateRecord
+{
+    protected static string $resource = SeoMetaResource::class;
+}

--- a/app/Filament/Resources/SeoMetaResource/Pages/EditSeoMeta.php
+++ b/app/Filament/Resources/SeoMetaResource/Pages/EditSeoMeta.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SeoMetaResource\Pages;
+
+use App\Filament\Resources\SeoMetaResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSeoMeta extends EditRecord
+{
+    protected static string $resource = SeoMetaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SeoMetaResource/Pages/ListSeoMeta.php
+++ b/app/Filament/Resources/SeoMetaResource/Pages/ListSeoMeta.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SeoMetaResource\Pages;
+
+use App\Filament\Resources\SeoMetaResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSeoMeta extends ListRecords
+{
+    protected static string $resource = SeoMetaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/SeoMeta.php
+++ b/app/Models/SeoMeta.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SeoMeta extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['page', 'title', 'description', 'keywords'];
+}

--- a/database/migrations/2025_09_01_000003_create_seo_meta_table.php
+++ b/database/migrations/2025_09_01_000003_create_seo_meta_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('seo_meta', function (Blueprint $table) {
+            $table->id();
+            $table->string('page')->unique();
+            $table->string('title')->nullable();
+            $table->text('description')->nullable();
+            $table->text('keywords')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('seo_meta');
+    }
+};

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -3,10 +3,17 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Metin2 - Descoperă lumea jocului Metin2, participă la bătălii epice și devino un erou legendar.">
-    <meta name="keywords" content="metin2, mmorpg, joc online, pvp, guild">
-    
-    <title>{{ config('app.name') }} @yield('title')</title>
+    @php
+        use App\Models\SeoMeta;
+        use Illuminate\Support\Facades\Route;
+        $routeName = Route::currentRouteName();
+        $seoMeta = SeoMeta::where('page', $routeName)->first();
+        $defaultTitle = config('app.name') . ' ' . trim($__env->yieldContent('title'));
+    @endphp
+
+    <title>{{ $seoMeta->title ?? $defaultTitle }}</title>
+    <meta name="description" content="{{ $seoMeta->description ?? 'Metin2 - Descoperă lumea jocului Metin2, participă la bătălii epice și devino un erou legendar.' }}">
+    <meta name="keywords" content="{{ $seoMeta->keywords ?? 'metin2, mmorpg, joc online, pvp, guild' }}">
     
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">


### PR DESCRIPTION
## Summary
- support SEO meta per route
- manage SEO entries from Filament admin

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68569ccaaca0832c9fc747a3423340b9