### PR TITLE
Fix SeoMeta table name

### DIFF
--- a/app/Models/SeoMeta.php
+++ b/app/Models/SeoMeta.php
@@ -9,5 +9,10 @@ class SeoMeta extends Model
 {
     use HasFactory;
 
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'seo_meta';
+
     protected $fillable = ['page', 'title', 'description', 'keywords'];
 }


### PR DESCRIPTION
## Summary
- map SeoMeta model to `seo_meta` table

## Testing
- `composer install`
- `composer test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68569dd2a9e4832c8a7e6e73790f0cf1