### PR TITLE
Fix create button in gallery items

### DIFF
--- a/app/Filament/Resources/GalleryItemResource/Pages/ListGalleryItems.php
+++ b/app/Filament/Resources/GalleryItemResource/Pages/ListGalleryItems.php
@@ -3,9 +3,17 @@
 namespace App\Filament\Resources\GalleryItemResource\Pages;
 
 use App\Filament\Resources\GalleryItemResource;
+use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListGalleryItems extends ListRecords
 {
     protected static string $resource = GalleryItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- show `Create` button on the Filament Gallery Items list page

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68569e0ef990832ca1c6a7922c124555