### PR TITLE
Fix SEO page titles

### DIFF
--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -1,5 +1,5 @@
 @extends('layout')
-@section('title', ' - Events')
+@section('title', 'Events')
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">

--- a/resources/views/itemshop/category.blade.php
+++ b/resources/views/itemshop/category.blade.php
@@ -1,5 +1,7 @@
 @extends('itemshop.layouts.app')
 
+@section('title', 'Item Shop - ' . $category->name)
+
 @section('content')
     <h2 class="text-lg font-bold text-yellow-400 mb-3">📦 {{ $category->name }}</h2>
 

--- a/resources/views/itemshop/index.blade.php
+++ b/resources/views/itemshop/index.blade.php
@@ -1,5 +1,7 @@
 @extends('itemshop.layouts.app')
 
+@section('title', 'Item Shop')
+
 @section('content')
     <!-- Top 3 Most Purchased -->
     <h2 class="text-lg font-bold text-yellow-400 mb-3">🔥 Most Purchased</h2>

--- a/resources/views/itemshop/layouts/app.blade.php
+++ b/resources/views/itemshop/layouts/app.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Item-Shop</title>
+    <title>{{ config('app.name') }} - @yield('title', 'Item Shop')</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
         .no-scrollbar::-webkit-scrollbar {

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -8,7 +8,8 @@
         use Illuminate\Support\Facades\Route;
         $routeName = Route::currentRouteName();
         $seoMeta = SeoMeta::where('page', $routeName)->first();
-        $defaultTitle = config('app.name') . ' ' . trim($__env->yieldContent('title'));
+        $pageTitle = trim($__env->yieldContent('title'));
+        $defaultTitle = trim(config('app.name') . ($pageTitle ? ' - ' . $pageTitle : ''));
     @endphp
 
     <title>{{ $seoMeta->title ?? $defaultTitle }}</title>

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -1,5 +1,5 @@
 @extends('layout')
-@section('title', ' - New Ticket')
+@section('title', 'New Ticket')
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -1,5 +1,5 @@
 @extends('layout')
-@section('title', ' - Tickets')
+@section('title', 'Tickets')
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -1,5 +1,5 @@
 @extends('layout')
-@section('title', ' - View Ticket')
+@section('title', 'View Ticket')
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">


### PR DESCRIPTION
## Summary
- prefix page titles with site name for better SEO
- update event and ticket page titles
- add dynamic titles for item shop pages

## Testing
- `./vendor/bin/phpunit` *(fails: InvalidArgumentException: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68569ed8111c832c994f8254e93f6f6f