### PR TITLE
Fix translation quoting error

### DIFF
--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -156,7 +156,7 @@ return [
     'guild_system' => 'Guild System',
     'form_powerful_alliances' => 'Form powerful alliances, conquer territories, and participate in massive guild wars.',
     'item_crafting' => 'Item Crafting',
-    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character's power.',
+    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character\'s power.',
     'game_screenshots' => 'Game Screenshots',
     'view_gallery' => 'View Gallery',
     'comments' => 'Comments',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -156,7 +156,7 @@ return [
     'guild_system' => 'Guild System',
     'form_powerful_alliances' => 'Form powerful alliances, conquer territories, and participate in massive guild wars.',
     'item_crafting' => 'Item Crafting',
-    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character's power.',
+    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character\'s power.',
     'game_screenshots' => 'Game Screenshots',
     'view_gallery' => 'View Gallery',
     'comments' => 'Comments',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -156,7 +156,7 @@ return [
     'guild_system' => 'Guild System',
     'form_powerful_alliances' => 'Form powerful alliances, conquer territories, and participate in massive guild wars.',
     'item_crafting' => 'Item Crafting',
-    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character's power.',
+    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character\'s power.',
     'game_screenshots' => 'Game Screenshots',
     'view_gallery' => 'View Gallery',
     'comments' => 'Comments',

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -156,7 +156,7 @@ return [
     'guild_system' => 'Guild System',
     'form_powerful_alliances' => 'Form powerful alliances, conquer territories, and participate in massive guild wars.',
     'item_crafting' => 'Item Crafting',
-    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character's power.',
+    'discover_rare_materials' => 'Discover rare materials and craft legendary equipment to enhance your character\'s power.',
     'game_screenshots' => 'Game Screenshots',
     'view_gallery' => 'View Gallery',
     'comments' => 'Comments',


### PR DESCRIPTION
## Summary
- fix apostrophe in English, German, French and Turkish translations that was breaking parsing

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a6e52fcc832ca78f4c44516b7c1a