### PR TITLE
Fix login redirect routes

### DIFF
--- a/app/Http/Controllers/ForgotPasswordController.php
+++ b/app/Http/Controllers/ForgotPasswordController.php
@@ -71,7 +71,7 @@ class ForgotPasswordController extends Controller
 
         DB::table('password_reset_tokens')->where('email', $request->email)->delete();
 
-        return redirect()->route('metin2.login')->with('success', __('messages.password_reset_success'));
+        return redirect()->route('index')->with('success', __('messages.password_reset_success'));
     }
 
     public function cancel(Request $request, string $token)

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -29,7 +29,7 @@ class PasswordController extends Controller
         $sessionUser = session('metin2_user');
     
         if (!$sessionUser) {
-            return redirect()->route('metin2.login')->withErrors(['current_password' => __('messages.error_not_authenticated')]);
+            return redirect()->route('index')->withErrors(['current_password' => __('messages.error_not_authenticated')]);
         }
     
         // 🔹 3. Verificăm dacă utilizatorul există în baza de date


### PR DESCRIPTION
## Summary
- redirect password reset success to homepage
- redirect non-authenticated password update to homepage

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a900be74832c952ae5bfaec8e741