### PR TITLE
Add terms and privacy pages

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -57,5 +57,8 @@ class DatabaseSeeder extends Seeder
         ], [
             'value' => '1',
         ]);
+
+        // Seed static pages like Privacy Policy and Terms of Service
+        $this->call(PagesSeeder::class);
     }
 }

--- a/database/seeders/PagesSeeder.php
+++ b/database/seeders/PagesSeeder.php
@@ -11,11 +11,24 @@ class PagesSeeder extends Seeder
     public function run()
     {
         Page::updateOrCreate(['title' => 'Privacy Policy'], [
-            'content' => 'Your privacy policy text here...'
+            'content' => <<<EOT
+Play-Metin2.com respectă confidențialitatea utilizatorilor. Informațiile furnizate la înregistrare sunt folosite doar pentru administrarea contului de joc de pe serverul **New World**.
+
+1. Datele personale nu vor fi partajate cu terți decât dacă legea impune acest lucru.
+2. Folosim cookie-uri pentru a îmbunătăți funcționarea site-ului și pentru statistici anonime.
+3. Puteți solicita oricând ștergerea contului și a datelor asociate, contactând echipa noastră.
+EOT
         ]);
 
         Page::updateOrCreate(['title' => 'Terms of Service'], [
-            'content' => 'Your terms of service text here...'
+            'content' => <<<EOT
+Prin accesarea site-ului Play-Metin2.com și a serverului **New World**, sunteți de acord cu următorii termeni:
+
+1. Conturile sunt personale; securitatea lor este responsabilitatea utilizatorului.
+2. Este interzisă utilizarea oricăror programe sau exploatarea erorilor de joc.
+3. Echipa își rezervă dreptul de a modifica regulile și conținutul serverului fără notificare prealabilă.
+4. Încălcarea acestor termeni poate conduce la suspendarea permanentă a contului.
+EOT
         ]);
     }
 }

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -53,7 +53,6 @@
                                 <li><a href="/top-players" class="text-white hover:text-green-400 glow-link py-2">Rankings</a></li>
                                 <li><a href="/tickets" class="text-white hover:text-green-400 glow-link py-2">{{ __('messages.menu_tickets') }}</a></li>
                                 <li><a href="/guides" class="text-white hover:text-green-400 glow-link py-2">Guides</a></li>
-                                <li><a href="/contact" class="text-white hover:text-green-400 glow-link py-2">{{ __('messages.menu_contact') }}</a></li>
                             </ul>
                             
                             <!-- Language Switcher -->
@@ -91,7 +90,6 @@
                     <a href="/top-players" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">Rankings</a>
                     <a href="/tickets" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">{{ __('messages.menu_tickets') }}</a>
                     <a href="/guides" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">Guides</a>
-                    <a href="/contact" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">{{ __('messages.menu_contact') }}</a>
                 </div>
             </div>
         </header>
@@ -345,7 +343,7 @@
                     <div class="flex space-x-6">
                         <a href="{{ route('page.show', 'Privacy Policy') }}" class="text-gray-400 hover:text-white transition glow-link">Privacy Policy</a>
                         <a href="{{ route('page.show', 'Terms of Service') }}" class="text-gray-400 hover:text-white transition glow-link">Terms of Service</a>
-                        <a href="{{ route('page.show', 'Contact') }}" class="text-gray-400 hover:text-white transition glow-link">Contact</a>
+                        <a href="{{ route('contact.show') }}" class="text-gray-400 hover:text-white transition glow-link">Contact</a>
                     </div>
                     
                     <div>


### PR DESCRIPTION
## Summary
- seed Terms of Service & Privacy Policy pages for the New World server
- link Contact in footer to the correct route
- remove Contact from header menus
- make page seeder run from `DatabaseSeeder`

## Testing
- `composer test` *(fails: phpunit not found / dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856a97891c4832caec75d69cd9f6341