### PR TITLE
Improve news comment box and login overlay

### DIFF
--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -23,24 +23,46 @@
     <h3 class="text-lg font-semibold mb-4 text-green-400">{{ __('messages.comments') }}</h3>
 
     @if(Auth::guard('metin2')->check())
-        <form action="{{ route('news.comment', $news->slug) }}" method="POST" class="mb-4">
+        <form action="{{ route('news.comment', $news->slug) }}" method="POST" class="mb-4 space-y-2">
             @csrf
-            <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+            <div id="editor" class="bg-gray-800 text-white rounded"></div>
+            <input type="hidden" name="content" id="content-input">
             <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
         </form>
+        <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+        <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const quill = new Quill('#editor', {
+                    theme: 'snow',
+                    modules: {
+                        toolbar: [
+                            ['bold', 'italic', 'underline'],
+                            [{ 'align': [] }],
+                            ['clean']
+                        ]
+                    }
+                });
+                const form = document.querySelector('form');
+                form.addEventListener('submit', function () {
+                    document.getElementById('content-input').value = quill.root.innerHTML;
+                });
+            });
+        </script>
     @else
-        <p class="mb-2 text-red-500">{{ __('messages.news_comment_login_required') }}</p>
-        <form class="mb-4">
-            <input type="text" value="Unknown" class="w-full mb-2 p-2 bg-gray-800 text-white rounded" disabled />
-            <textarea class="w-full p-2 bg-gray-800 text-white rounded" disabled></textarea>
-            <button class="mt-2 px-4 py-2 bg-gray-600 text-white rounded" disabled>{{ __('messages.submit') }}</button>
-        </form>
+        <div class="relative mb-4">
+            <textarea class="w-full p-2 bg-gray-800 text-white rounded h-32" disabled></textarea>
+            <div class="absolute inset-0 flex items-center justify-center">
+                <p class="bg-black bg-opacity-75 text-white p-4 rounded">{{ __('messages.news_comment_login_required') }}</p>
+            </div>
+            <button class="mt-2 px-4 py-2 bg-gray-600 text-white rounded w-full" disabled>{{ __('messages.submit') }}</button>
+        </div>
     @endif
 
     <div class="space-y-4">
         @foreach ($comments as $comment)
             <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
-                <p class="text-sm text-gray-300">{{ $comment->content }}</p>
+                <div class="text-sm text-gray-300 prose prose-invert">{!! $comment->content !!}</div>
                 <div class="text-xs text-gray-500 mt-2 flex items-center gap-2">
                     <form action="{{ route('comments.like', $comment) }}" method="POST" class="inline">
                         @csrf


### PR DESCRIPTION
## Summary
- add Quill rich text editor for news comments
- overlay the comment box with a login required message for guests
- render comment content as HTML

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ac64a9a8832c9548a34214c2efa9