### PR TITLE
Add ticket response in filament

### DIFF
--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -26,6 +26,10 @@ class TicketResource extends Resource
             TextInput::make('user_id')->numeric()->required(),
             TextInput::make('title')->required()->maxLength(255),
             Textarea::make('message')->required(),
+            Textarea::make('response')
+                ->label('Response')
+                ->columnSpanFull()
+                ->rows(5),
             Select::make('status')
                 ->options([
                     'open' => 'Open',
@@ -42,6 +46,7 @@ class TicketResource extends Resource
                 TextColumn::make('id')->sortable(),
                 TextColumn::make('user_id')->sortable(),
                 TextColumn::make('title')->searchable(),
+                TextColumn::make('response')->limit(50)->label('Response'),
                 TextColumn::make('status')->badge(),
                 TextColumn::make('created_at')->dateTime()->sortable(),
             ])

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -9,7 +9,7 @@ class Ticket extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'title', 'message', 'status'];
+    protected $fillable = ['user_id', 'title', 'message', 'status', 'response'];
 
     public function user()
     {

--- a/database/migrations/2025_09_01_000004_add_response_to_tickets_table.php
+++ b/database/migrations/2025_09_01_000004_add_response_to_tickets_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->text('response')->nullable()->after('message');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->dropColumn('response');
+        });
+    }
+};

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -170,6 +170,7 @@ return [
     'new_ticket' => 'New Ticket',
     'view_ticket' => 'View Ticket',
     'status' => 'Status',
+    'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -170,6 +170,7 @@ return [
     'new_ticket' => 'New Ticket',
     'view_ticket' => 'View Ticket',
     'status' => 'Status',
+    'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -170,6 +170,7 @@ return [
     'new_ticket' => 'New Ticket',
     'view_ticket' => 'View Ticket',
     'status' => 'Status',
+    'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -170,6 +170,7 @@ return [
     'new_ticket' => 'Bilet nou',
     'view_ticket' => 'Vizualizați biletul',
     'status' => 'Statut',
+    'response' => 'Răspuns',
     'posted_by' => 'Postat de:',
     'news' => 'Ştiri',
 ];

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -170,6 +170,7 @@ return [
     'new_ticket' => 'New Ticket',
     'view_ticket' => 'View Ticket',
     'status' => 'Status',
+    'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
 ];

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -6,5 +6,11 @@
     <h2 class="text-xl font-semibold mb-4 text-green-400">{{ $ticket->title }}</h2>
     <p class="text-gray-300 mb-4">{{ $ticket->message }}</p>
     <p class="text-sm text-gray-500">{{ __('messages.status') }}: {{ $ticket->status }}</p>
+    @if($ticket->response)
+        <div class="mt-4 p-4 bg-gray-800 bg-opacity-50 rounded-lg border border-gray-700">
+            <h3 class="text-lg font-semibold mb-2 text-blue-400">{{ __('messages.response') }}</h3>
+            <p class="text-gray-300">{{ $ticket->response }}</p>
+        </div>
+    @endif
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- allow storing ticket responses in DB
- expose response column in Filament resource
- display ticket responses in front-end views
- add translation key for response

## Testing
- `composer test` *(fails: Session is missing expected key errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae3a12d0832c8c75f674a81f0f9a