### PR TITLE
Add French option and translations

### DIFF
--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -1,12 +1,13 @@
 <?php
 
 return [
-    'menu_home' => 'Home',
-    'menu_login' => 'Login',
-    'menu_logout' => 'Logout',
-    'menu_register' => 'Register',
-    'menu_download' => 'Download',
-    'menu_events' => 'Events',
+    // Navigation
+    'menu_home' => 'Accueil',
+    'menu_login' => 'Connexion',
+    'menu_logout' => 'Déconnexion',
+    'menu_register' => 'Inscription',
+    'menu_download' => 'Télécharger',
+    'menu_events' => 'Événements',
     'menu_tickets' => 'Tickets',
     'sidebar_left_top_players_title' => 'Top Players',
     'sidebar_left_top_players_rank' => 'Rank',

--- a/resources/views/layout.blade-backup.php
+++ b/resources/views/layout.blade-backup.php
@@ -88,6 +88,9 @@
                     <a href="{{ route('switch.lang', ['lang' => 'ro']) }}" class="flex items-center px-4 py-2 hover:bg-gray-100 transition">
                         🇷🇴 <span class="ml-2 text-gray-900">Română</span>
                     </a>
+                    <a href="{{ route('switch.lang', ['lang' => 'fr']) }}" class="flex items-center px-4 py-2 hover:bg-gray-100 transition">
+                        🇫🇷 <span class="ml-2 text-gray-900">Français</span>
+                    </a>
                 </div>
             </div>
         </nav>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -64,8 +64,11 @@
                                     <a href="{{ route('switch.lang', ['lang' => 'en']) }}" class="flex items-center px-4 py-2 hover:bg-gray-700 transition rounded-t-lg" role="menuitem">
                                         🇬🇧 <span class="ml-2 text-white">English</span>
                                     </a>
-                                    <a href="{{ route('switch.lang', ['lang' => 'ro']) }}" class="flex items-center px-4 py-2 hover:bg-gray-700 transition rounded-b-lg" role="menuitem">
+                                    <a href="{{ route('switch.lang', ['lang' => 'ro']) }}" class="flex items-center px-4 py-2 hover:bg-gray-700 transition" role="menuitem">
                                         🇷🇴 <span class="ml-2 text-white">Română</span>
+                                    </a>
+                                    <a href="{{ route('switch.lang', ['lang' => 'fr']) }}" class="flex items-center px-4 py-2 hover:bg-gray-700 transition rounded-b-lg" role="menuitem">
+                                        🇫🇷 <span class="ml-2 text-white">Français</span>
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- update French translations for navigation
- add French option to language dropdown menus

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856afef8ec8832ca8e7f4043d49e04d