### PR TITLE
Fix duplicate dash in page titles

### DIFF
--- a/app/Http/Controllers/DownloadController.php
+++ b/app/Http/Controllers/DownloadController.php
@@ -27,7 +27,7 @@ class DownloadController extends Controller
         return view('download', [
             'downloads' => $downloads,
             'description' => $finalDescription,
-            'title' => ' - Download',
+            'title' => 'Download',
         ]);
     }
 }

--- a/app/Http/Controllers/ForgotPasswordController.php
+++ b/app/Http/Controllers/ForgotPasswordController.php
@@ -15,7 +15,7 @@ class ForgotPasswordController extends Controller
     public function showLinkRequestForm()
     {
         return view('auth.forgot-password', [
-            'title' => ' - '.__('messages.forgot_password_title'),
+            'title' => __('messages.forgot_password_title'),
         ]);
     }
 
@@ -48,7 +48,7 @@ class ForgotPasswordController extends Controller
     public function showResetForm(string $token)
     {
         return view('auth.reset-password', [
-            'title' => ' - '.__('messages.reset_password_title'),
+            'title' => __('messages.reset_password_title'),
             'token' => $token,
         ]);
     }

--- a/app/Http/Controllers/GuildController.php
+++ b/app/Http/Controllers/GuildController.php
@@ -57,7 +57,7 @@ class GuildController extends Controller
 
         return view('top-guilds', [
             'guilds' => $guilds,
-            'title' => ' - Top Guilds'
+            'title' => 'Top Guilds'
         ]);        
     }
 }

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -13,7 +13,7 @@ class PasswordController extends Controller
     public function showChangePasswordForm()
     {
         return view('auth.change-password', [
-            'title' => ' - Change Password',
+            'title' => 'Change Password',
         ]);
     }
 

--- a/app/Http/Controllers/PlayerController.php
+++ b/app/Http/Controllers/PlayerController.php
@@ -83,7 +83,7 @@ return view('top-players', [
     'maxLevel' => $maxLevel,
     'minPlaytime' => $minPlaytime,
     'maxPlaytime' => $maxPlaytime,
-    'title' => ' - Top Players',
+    'title' => 'Top Players',
 ]);
 
     }

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -18,7 +18,7 @@ class RegisterController extends Controller
     public function showRegisterForm()
     {
         return view('register', [
-            'title' => ' - Register', // Titlul pentru pagina de înregistrare
+            'title' => 'Register', // Titlul pentru pagina de înregistrare
             'refferEnabled' => Setting::isEnabled('reffer_enabled', false),
         ]);
     }


### PR DESCRIPTION
## Summary
- clean up page title values in controllers

## Testing
- `composer install --no-interaction` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b20a8f64832ca5a218d685a21684