### PR TITLE
Add character management page

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class CharacterController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::guard('metin2')->user();
+
+        $index = DB::connection('player')
+            ->table('player_index')
+            ->where('account_id', $user->id)
+            ->first();
+
+        $ids = collect([$index->pid1 ?? null, $index->pid2 ?? null, $index->pid3 ?? null, $index->pid4 ?? null, $index->pid5 ?? null])
+            ->filter()
+            ->all();
+
+        $characters = [];
+        if (!empty($ids)) {
+            $characters = DB::connection('player')
+                ->table('player')
+                ->select('id', 'name', 'level', 'playtime')
+                ->whereIn('id', $ids)
+                ->orderBy('level', 'desc')
+                ->get();
+        }
+
+        return view('characters.index', [
+            'characters' => $characters,
+        ]);
+    }
+}

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -173,4 +173,9 @@ return [
     'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
+    'character_management' => 'Charakterverwaltung',
+    'characters' => 'Charaktere',
+    'my_characters' => 'Meine Charaktere',
+    'no_characters_found' => 'Keine Charaktere gefunden.',
+    'play_time' => 'Spielzeit',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -173,4 +173,9 @@ return [
     'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
+    'character_management' => 'Character Management',
+    'characters' => 'Characters',
+    'my_characters' => 'My Characters',
+    'no_characters_found' => 'No characters found.',
+    'play_time' => 'Playtime',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -174,4 +174,9 @@ return [
     'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
+    'character_management' => 'Gestion des personnages',
+    'characters' => 'Personnages',
+    'my_characters' => 'Mes personnages',
+    'no_characters_found' => 'Aucun personnage trouvé.',
+    'play_time' => 'Temps de jeu',
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -173,4 +173,9 @@ return [
     'response' => 'Răspuns',
     'posted_by' => 'Postat de:',
     'news' => 'Ştiri',
+    'character_management' => 'Managementul personajelor',
+    'characters' => 'Personaje',
+    'my_characters' => 'Personajele mele',
+    'no_characters_found' => 'Nu s-au găsit personaje.',
+    'play_time' => 'Timp jucat',
 ];

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -173,4 +173,9 @@ return [
     'response' => 'Response',
     'posted_by' => 'Posted by:',
     'news' => 'News',
+    'character_management' => 'Karakter Yönetimi',
+    'characters' => 'Karakterler',
+    'my_characters' => 'Karakterlerim',
+    'no_characters_found' => 'Karakter bulunamadı.',
+    'play_time' => 'Oynama süresi',
 ];

--- a/resources/views/characters/index.blade.php
+++ b/resources/views/characters/index.blade.php
@@ -1,0 +1,23 @@
+@extends('layout')
+@section('title', __('messages.character_management'))
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    <h2 class="text-xl font-semibold mb-4 text-green-400">{{ __('messages.my_characters') }}</h2>
+    <ul class="space-y-4">
+        @forelse($characters as $character)
+            <li class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
+                <div class="flex justify-between">
+                    <span class="font-bold text-yellow-400">{{ $character->name }}</span>
+                    <span class="text-sm text-gray-300">Lv {{ $character->level }}</span>
+                </div>
+                <div class="text-xs text-gray-400 mt-1">
+                    {{ __('messages.play_time') }}: {{ $character->playtime }}
+                </div>
+            </li>
+        @empty
+            <li class="text-gray-400">{{ __('messages.no_characters_found') }}</li>
+        @endforelse
+    </ul>
+</div>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -204,14 +204,9 @@
                                 
                                 <!-- Disabled buttons with tooltips -->
                                 <div class="grid grid-cols-1 gap-3">
-                                    <div class="relative group">
-                                        <a href="javascript:void(0)" class="block w-full px-4 py-3 text-center bg-gray-800 text-white rounded-lg shadow-lg opacity-60 cursor-not-allowed" aria-disabled="true">
-                                            🎮 Character Management
-                                        </a>
-                                        <span class="absolute w-max left-1/2 -translate-x-1/2 -top-12 bg-black text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity z-10 pointer-events-none" role="tooltip">
-                                            🚧 Under Construction
-                                        </span>
-                                    </div>
+                                    <a href="{{ route('characters.index') }}" class="block w-full px-4 py-3 text-center bg-gray-800 hover:bg-gray-700 text-white rounded-lg shadow-lg transition" aria-label="Character Management">
+                                        🎮 {{ __('messages.character_management') }}
+                                    </a>
                                     
                                     <div class="relative group">
                                         <a href="javascript:void(0)" class="block w-full px-4 py-3 text-center bg-gray-800 text-white rounded-lg shadow-lg opacity-60 cursor-not-allowed" aria-disabled="true">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\NewsController;
 use App\Http\Controllers\GalleryController;
 use App\Http\Controllers\EventController;
+use App\Http\Controllers\CharacterController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\ForgotPasswordController;
@@ -86,6 +87,9 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
                 Route::get('/tickets/create', [TicketController::class, 'create'])->name('tickets.create');
                 Route::post('/tickets', [TicketController::class, 'store'])->name('tickets.store');
                 Route::get('/tickets/{ticket}', [TicketController::class, 'show'])->name('tickets.show');
+
+                // Character Management
+                Route::get('/characters', [CharacterController::class, 'index'])->name('characters.index');
     });
 	
 	Route::get('/check-auth', function () {

--- a/tests/Feature/CharacterManagementTest.php
+++ b/tests/Feature/CharacterManagementTest.php
@@ -1,0 +1,13 @@
+<?php
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CharacterManagementTest extends TestCase
+{
+    public function test_character_management_requires_authentication(): void
+    {
+        $response = $this->get('/characters');
+        $response->assertRedirect('/');
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CharacterController` and new `/characters` route
- enable Character Management link in layout
- add translations for new texts
- create view to list characters
- add feature test for Character Management authentication

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b1e349d8832c88750ed357681771