### PR TITLE
Add event time alerts

### DIFF
--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -172,5 +172,7 @@ return [
     'status' => 'Status',
     'response' => 'Response',
     'posted_by' => 'Posted by:',
+    'event_starts_in' => 'Starts in :time',
+    'event_started_ago' => 'Started :time ago',
     'news' => 'News',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -172,5 +172,7 @@ return [
     'status' => 'Status',
     'response' => 'Response',
     'posted_by' => 'Posted by:',
+    'event_starts_in' => 'Starts in :time',
+    'event_started_ago' => 'Started :time ago',
     'news' => 'News',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -173,5 +173,7 @@ return [
     'status' => 'Status',
     'response' => 'Response',
     'posted_by' => 'Posted by:',
+    'event_starts_in' => 'Starts in :time',
+    'event_started_ago' => 'Started :time ago',
     'news' => 'News',
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -172,5 +172,7 @@ return [
     'status' => 'Statut',
     'response' => 'Răspuns',
     'posted_by' => 'Postat de:',
+    'event_starts_in' => 'Începe în :time',
+    'event_started_ago' => 'A început acum :time',
     'news' => 'Ştiri',
 ];

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -172,5 +172,7 @@ return [
     'status' => 'Status',
     'response' => 'Response',
     'posted_by' => 'Posted by:',
+    'event_starts_in' => 'Starts in :time',
+    'event_started_ago' => 'Started :time ago',
     'news' => 'News',
 ];

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -6,9 +6,26 @@
     <h2 class="text-xl font-semibold mb-4 text-green-400">Upcoming Events</h2>
     <ul class="space-y-4">
         @foreach($events as $event)
-            <li class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
+            @php
+                $hoursUntilStart = now()->diffInHours($event->start_date, false);
+                if ($hoursUntilStart <= 0) {
+                    $alertClass = 'border-red-500';
+                    $textClass = 'text-red-400';
+                    $timeText = __('messages.event_started_ago', ['time' => $event->start_date->diffForHumans()]);
+                } elseif ($hoursUntilStart < 24) {
+                    $alertClass = 'border-yellow-500';
+                    $textClass = 'text-yellow-400';
+                    $timeText = __('messages.event_starts_in', ['time' => $event->start_date->diffForHumans()]);
+                } else {
+                    $alertClass = 'border-green-500';
+                    $textClass = 'text-green-400';
+                    $timeText = __('messages.event_starts_in', ['time' => $event->start_date->diffForHumans()]);
+                }
+            @endphp
+            <li class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700 border-l-4 {{ $alertClass }}">
                 <h3 class="font-bold text-yellow-400 text-lg">{{ $event->title }}</h3>
                 <p class="text-gray-300 text-sm">{{ $event->start_date->format('Y-m-d H:i') }}</p>
+                <p class="{{ $textClass }} text-sm font-semibold">{{ $timeText }}</p>
                 @if($event->description)
                     <div class="mt-2 text-gray-300 prose prose-invert max-w-none">
                         {!! $event->description !!}


### PR DESCRIPTION
## Summary
- show remaining time until an event starts with color-coded alerts
- add translations for the new messages in all languages

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b25fc2a0832ca9745602aa0fd2c9