### PR TITLE
Implement threaded ticket messages

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -11,6 +11,11 @@ class Ticket extends Model
 
     protected $fillable = ['user_id', 'title', 'message', 'status', 'response'];
 
+    public function messages()
+    {
+        return $this->hasMany(TicketMessage::class);
+    }
+
     public function user()
     {
         return $this->belongsTo(Metin2User::class, 'user_id');

--- a/app/Models/TicketMessage.php
+++ b/app/Models/TicketMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TicketMessage extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['ticket_id', 'author', 'content'];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+}

--- a/database/migrations/2025_10_01_000001_create_ticket_messages_table.php
+++ b/database/migrations/2025_10_01_000001_create_ticket_messages_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained()->cascadeOnDelete();
+            $table->string('author');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_messages');
+    }
+};

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -4,13 +4,23 @@
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
     <h2 class="text-xl font-semibold mb-4 text-green-400">{{ $ticket->title }}</h2>
-    <p class="text-gray-300 mb-4">{{ $ticket->message }}</p>
     <p class="text-sm text-gray-500">{{ __('messages.status') }}: {{ $ticket->status }}</p>
-    @if($ticket->response)
-        <div class="mt-4 p-4 bg-gray-800 bg-opacity-50 rounded-lg border border-gray-700">
-            <h3 class="text-lg font-semibold mb-2 text-blue-400">{{ __('messages.response') }}</h3>
-            <p class="text-gray-300">{{ $ticket->response }}</p>
-        </div>
+
+    <div class="space-y-4 mt-4">
+        @foreach($ticket->messages as $message)
+            <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
+                <div class="text-gray-300">{{ $message->content }}</div>
+                <div class="text-xs text-gray-400 mt-1">{{ __('messages.posted_by') }} {{ $message->author }} · {{ $message->created_at->diffForHumans() }}</div>
+            </div>
+        @endforeach
+    </div>
+
+    @if($ticket->status === 'open')
+        <form action="{{ route('tickets.message', $ticket) }}" method="POST" class="mt-4 space-y-2">
+            @csrf
+            <textarea name="message" class="w-full p-2 bg-gray-800 text-white rounded" rows="4" required></textarea>
+            <button class="px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
+        </form>
     @endif
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,26 +1,24 @@
 <?php
 
+use App\Http\Controllers\Auth\Metin2AuthController;
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\ContactController;
+use App\Http\Controllers\DownloadController;
+use App\Http\Controllers\EventController;
+use App\Http\Controllers\ForgotPasswordController;
+use App\Http\Controllers\GalleryController;
+use App\Http\Controllers\GuildController;
+use App\Http\Controllers\ItemShopController;
+use App\Http\Controllers\LanguageController;
+use App\Http\Controllers\NewsController;
+use App\Http\Controllers\PageController;
+use App\Http\Controllers\PasswordController;
+use App\Http\Controllers\PlayerController;
+use App\Http\Controllers\RegisterController;
+use App\Http\Controllers\TicketController;
+use App\Http\Controllers\WelcomeController;
 use App\Http\Middleware\LanguageMiddleware;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\PlayerController;
-use App\Http\Controllers\WelcomeController;
-use App\Http\Controllers\LanguageController;
-use App\Http\Controllers\GuildController;
-use App\Http\Controllers\RegisterController;
-use App\Http\Controllers\DownloadController;
-use App\Http\Controllers\PageController;
-use App\Http\Controllers\Auth\Metin2AuthController;
-use Livewire\Livewire;
-use App\Http\Livewire\Auth\Metin2Login;
-use App\Http\Controllers\PasswordController;
-use App\Http\Controllers\ItemShopController;
-use App\Http\Controllers\CategoryController;
-use App\Http\Controllers\NewsController;
-use App\Http\Controllers\GalleryController;
-use App\Http\Controllers\EventController;
-use App\Http\Controllers\TicketController;
-use App\Http\Controllers\ContactController;
-use App\Http\Controllers\ForgotPasswordController;
 
 // Aplica middleware-ul global pentru toate rutele
 Route::middleware([LanguageMiddleware::class])->group(function () {
@@ -33,64 +31,64 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
 
     // 🔹 Ruta pentru activarea contului prin email
     Route::get('/activate/{token}', [RegisterController::class, 'activateAccount'])->name('account.activate');
-	
-	Route::get('/download', [DownloadController::class, 'index'])->name('download');
-	
-        Route::get('/page/{slug}', [PageController::class, 'show'])->name('page.show');
-        Route::get('/events', [EventController::class, 'index'])->name('events.index');
 
-        // Contact
-        Route::get('/contact', [ContactController::class, 'show'])->name('contact.show');
-        Route::post('/contact', [ContactController::class, 'submit'])->name('contact.submit');
+    Route::get('/download', [DownloadController::class, 'index'])->name('download');
 
-        // News routes
-        Route::get('/news', [NewsController::class, 'index'])->name('news.index');
-        Route::get('/news/category/{slug}', [NewsController::class, 'category'])->name('news.category');
-        Route::get('/news/author/{author}', [NewsController::class, 'author'])->name('news.author');
-        Route::get('/news/{slug}', [NewsController::class, 'show'])->name('news.show');
-        Route::post('/news/{slug}/comment', [NewsController::class, 'comment'])->name('news.comment');
-        Route::post('/comments/{comment}/like', [NewsController::class, 'like'])->name('comments.like');
-        Route::post('/comments/{comment}/dislike', [NewsController::class, 'dislike'])->name('comments.dislike');
-        Route::post('/comments/{comment}/reply', [NewsController::class, 'reply'])->name('comments.reply');
-        Route::post('/news/{news}/like', [NewsController::class, 'likeNews'])->name('news.like');
-        Route::post('/news/{news}/dislike', [NewsController::class, 'dislikeNews'])->name('news.dislike');
+    Route::get('/page/{slug}', [PageController::class, 'show'])->name('page.show');
+    Route::get('/events', [EventController::class, 'index'])->name('events.index');
 
-        // Gallery routes
-        Route::get('/screenshots', [GalleryController::class, 'index'])->name('gallery.index');
-        Route::get('/gallery/{item}', [GalleryController::class, 'show'])->name('gallery.show');
-        Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
-        Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
-        Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
+    // Contact
+    Route::get('/contact', [ContactController::class, 'show'])->name('contact.show');
+    Route::post('/contact', [ContactController::class, 'submit'])->name('contact.submit');
 
-        // Password reset routes
-        Route::get('/forgot-password', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
-        Route::post('/forgot-password', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
-        Route::get('/reset-password/{token}', [ForgotPasswordController::class, 'showResetForm'])->name('password.reset.form');
-        Route::post('/reset-password', [ForgotPasswordController::class, 'reset'])->name('password.update.reset');
-        Route::get('/cancel-reset/{token}', [ForgotPasswordController::class, 'cancel'])->name('password.reset.cancel');
-	
-        Route::view('/metin2/login', 'auth.login')->name('metin2.login.form');
-        Route::post('/metin2/login', [Metin2AuthController::class, 'login'])->name('metin2.login');
-	Route::post('/metin2/logout', [Metin2AuthController::class, 'logout'])->name('metin2.logout');
-	Route::middleware(['metin2.auth'])->group(function () {
-		// Change Password
+    // News routes
+    Route::get('/news', [NewsController::class, 'index'])->name('news.index');
+    Route::get('/news/category/{slug}', [NewsController::class, 'category'])->name('news.category');
+    Route::get('/news/author/{author}', [NewsController::class, 'author'])->name('news.author');
+    Route::get('/news/{slug}', [NewsController::class, 'show'])->name('news.show');
+    Route::post('/news/{slug}/comment', [NewsController::class, 'comment'])->name('news.comment');
+    Route::post('/comments/{comment}/like', [NewsController::class, 'like'])->name('comments.like');
+    Route::post('/comments/{comment}/dislike', [NewsController::class, 'dislike'])->name('comments.dislike');
+    Route::post('/comments/{comment}/reply', [NewsController::class, 'reply'])->name('comments.reply');
+    Route::post('/news/{news}/like', [NewsController::class, 'likeNews'])->name('news.like');
+    Route::post('/news/{news}/dislike', [NewsController::class, 'dislikeNews'])->name('news.dislike');
+
+    // Gallery routes
+    Route::get('/screenshots', [GalleryController::class, 'index'])->name('gallery.index');
+    Route::get('/gallery/{item}', [GalleryController::class, 'show'])->name('gallery.show');
+    Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
+    Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
+    Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
+
+    // Password reset routes
+    Route::get('/forgot-password', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
+    Route::post('/forgot-password', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
+    Route::get('/reset-password/{token}', [ForgotPasswordController::class, 'showResetForm'])->name('password.reset.form');
+    Route::post('/reset-password', [ForgotPasswordController::class, 'reset'])->name('password.update.reset');
+    Route::get('/cancel-reset/{token}', [ForgotPasswordController::class, 'cancel'])->name('password.reset.cancel');
+
+    Route::view('/metin2/login', 'auth.login')->name('metin2.login.form');
+    Route::post('/metin2/login', [Metin2AuthController::class, 'login'])->name('metin2.login');
+    Route::post('/metin2/logout', [Metin2AuthController::class, 'logout'])->name('metin2.logout');
+    Route::middleware(['metin2.auth'])->group(function () {
+        // Change Password
         Route::get('/change-password', [PasswordController::class, 'showChangePasswordForm'])->name('password.change');
         Route::post('/change-password', [PasswordController::class, 'updatePassword'])->name('password.update');
-		
-                //Item Shop
-                Route::get('/itemshop', [ItemShopController::class, 'index'])->name('itemshop');
-                Route::get('/itemshop/category/{slug}', [CategoryController::class, 'show'])->name('categories.show');
 
-                // Tickets
-                Route::get('/tickets', [TicketController::class, 'index'])->name('tickets.index');
-                Route::get('/tickets/create', [TicketController::class, 'create'])->name('tickets.create');
-                Route::post('/tickets', [TicketController::class, 'store'])->name('tickets.store');
-                Route::get('/tickets/{ticket}', [TicketController::class, 'show'])->name('tickets.show');
+        // Item Shop
+        Route::get('/itemshop', [ItemShopController::class, 'index'])->name('itemshop');
+        Route::get('/itemshop/category/{slug}', [CategoryController::class, 'show'])->name('categories.show');
+
+        // Tickets
+        Route::get('/tickets', [TicketController::class, 'index'])->name('tickets.index');
+        Route::get('/tickets/create', [TicketController::class, 'create'])->name('tickets.create');
+        Route::post('/tickets', [TicketController::class, 'store'])->name('tickets.store');
+        Route::get('/tickets/{ticket}', [TicketController::class, 'show'])->name('tickets.show');
+        Route::post('/tickets/{ticket}/message', [TicketController::class, 'addMessage'])->name('tickets.message');
     });
-	
-	Route::get('/check-auth', function () {
-    return response()->json(['authenticated' => session()->has('metin2_user')]);
-});
+
+    Route::get('/check-auth', function () {
+        return response()->json(['authenticated' => session()->has('metin2_user')]);
+    });
 
 });
- 


### PR DESCRIPTION
## Summary
- allow multiple messages per ticket
- add `TicketMessage` model and migration
- show ticket message threads and a reply form
- store initial ticket message and allow posting new messages
- route for adding messages to existing tickets

## Testing
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6856b180fd80832c9039533cf292a4b8