### PR TITLE
Enable ticket re-opening via new replies

### DIFF
--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\TicketResource\Pages;
+use App\Filament\Resources\TicketResource\RelationManagers\MessagesRelationManager;
 use App\Models\Ticket;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -54,6 +55,13 @@ class TicketResource extends Resource
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            MessagesRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
+++ b/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Resources\TicketResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Forms\Components\Textarea;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Resources\RelationManagers\HasManyRelationManager;
+
+class MessagesRelationManager extends HasManyRelationManager
+{
+    protected static string $relationship = 'messages';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Textarea::make('content')
+                ->required()
+                ->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('author')->searchable(),
+                TextColumn::make('content')->limit(50)->html(),
+                TextColumn::make('created_at')->dateTime(),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+
+    public function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['author'] = auth()->user()->name;
+
+        return $data;
+    }
+
+    public function afterCreate(): void
+    {
+        $this->getOwnerRecord()->update(['status' => 'open']);
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -73,6 +73,10 @@ class TicketController extends Controller
             'content' => $request->message,
         ]);
 
+        if ($ticket->status === 'closed') {
+            $ticket->update(['status' => 'open']);
+        }
+
         return redirect()->back();
     }
 }

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -15,12 +15,10 @@
         @endforeach
     </div>
 
-    @if($ticket->status === 'open')
-        <form action="{{ route('tickets.message', $ticket) }}" method="POST" class="mt-4 space-y-2">
-            @csrf
-            <textarea name="message" class="w-full p-2 bg-gray-800 text-white rounded" rows="4" required></textarea>
-            <button class="px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
-        </form>
-    @endif
+    <form action="{{ route('tickets.message', $ticket) }}" method="POST" class="mt-4 space-y-2">
+        @csrf
+        <textarea name="message" class="w-full p-2 bg-gray-800 text-white rounded" rows="4" required></textarea>
+        <button class="px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
+    </form>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- show reply form even when ticket closed
- reopen tickets on new replies
- allow admins to manage ticket messages via Filament

## Testing
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b6261670832cbc753c1118898462