### PR TITLE
Add Metin2 character unstuck functionality

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -34,4 +34,37 @@ class CharacterController extends Controller
             'characters' => $characters,
         ]);
     }
+
+    public function unstuck($id)
+    {
+        $user = Auth::guard('metin2')->user();
+
+        $index = DB::connection('player')
+            ->table('player_index')
+            ->where('id', $user->id)
+            ->first();
+
+        $ids = collect([
+            $index->pid1 ?? null,
+            $index->pid2 ?? null,
+            $index->pid3 ?? null,
+            $index->pid4 ?? null,
+            $index->pid5 ?? null,
+        ])->filter()->all();
+
+        if (!in_array($id, $ids)) {
+            abort(403);
+        }
+
+        DB::connection('player')
+            ->table('player')
+            ->where('id', $id)
+            ->update([
+                'x' => 469300,
+                'y' => 964200,
+                'map_index' => 1,
+            ]);
+
+        return back()->with('success', __('messages.unstuck_success'));
+    }
 }

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -180,4 +180,6 @@ return [
     'my_characters' => 'Meine Charaktere',
     'no_characters_found' => 'Keine Charaktere gefunden.',
     'play_time' => 'Spielzeit',
+    'unstuck_character' => 'Charakter befreien',
+    'unstuck_success' => 'Dein Charakter wurde an einen sicheren Ort bewegt.',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -180,4 +180,6 @@ return [
     'my_characters' => 'My Characters',
     'no_characters_found' => 'No characters found.',
     'play_time' => 'Playtime',
+    'unstuck_character' => 'Unstuck Character',
+    'unstuck_success' => 'Your character has been moved to a safe location.',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -181,4 +181,6 @@ return [
     'my_characters' => 'Mes personnages',
     'no_characters_found' => 'Aucun personnage trouvé.',
     'play_time' => 'Temps de jeu',
+    'unstuck_character' => 'Débloquer le personnage',
+    'unstuck_success' => 'Votre personnage a été déplacé vers un endroit sûr.',
 ];

--- a/resources/lang/ro/messages.php
+++ b/resources/lang/ro/messages.php
@@ -180,4 +180,6 @@ return [
     'my_characters' => 'Personajele mele',
     'no_characters_found' => 'Nu s-au găsit personaje.',
     'play_time' => 'Timp jucat',
+    'unstuck_character' => 'Deblochează personajul',
+    'unstuck_success' => 'Personajul a fost mutat într-o locație sigură.',
 ];

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -180,4 +180,6 @@ return [
     'my_characters' => 'Karakterlerim',
     'no_characters_found' => 'Karakter bulunamadı.',
     'play_time' => 'Oynama süresi',
+    'unstuck_character' => 'Karakteri Kurtar',
+    'unstuck_success' => 'Karakteriniz güvenli bir konuma taşındı.',
 ];

--- a/resources/views/characters/index.blade.php
+++ b/resources/views/characters/index.blade.php
@@ -3,6 +3,12 @@
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    @if(session('success'))
+        <div class="bg-green-900/30 text-green-400 p-2 rounded-lg mb-4">{{ session('success') }}</div>
+    @endif
+    @if(session('error'))
+        <div class="bg-red-900/30 text-red-400 p-2 rounded-lg mb-4">{{ session('error') }}</div>
+    @endif
     <h2 class="text-xl font-semibold mb-4 text-green-400">{{ __('messages.my_characters') }}</h2>
     <ul class="space-y-4">
         @forelse($characters as $character)
@@ -14,6 +20,12 @@
                 <div class="text-xs text-gray-400 mt-1">
                     {{ __('messages.play_time') }}: {{ $character->playtime }}
                 </div>
+                <form action="{{ route('characters.unstuck', $character->id) }}" method="POST" class="mt-2">
+                    @csrf
+                    <button type="submit" class="px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white text-xs rounded">
+                        {{ __('messages.unstuck_character') }}
+                    </button>
+                </form>
             </li>
         @empty
             <li class="text-gray-400">{{ __('messages.no_characters_found') }}</li>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -208,14 +208,6 @@
                                         🎮 {{ __('messages.character_management') }}
                                     </a>
                                     
-                                    <div class="relative group">
-                                        <a href="javascript:void(0)" class="block w-full px-4 py-3 text-center bg-gray-800 text-white rounded-lg shadow-lg opacity-60 cursor-not-allowed" aria-disabled="true">
-                                            🚀 Unstuck Character
-                                        </a>
-                                        <span class="absolute w-max left-1/2 -translate-x-1/2 -top-12 bg-black text-white text-xs rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity z-10 pointer-events-none" role="tooltip">
-                                            🚧 Under Construction
-                                        </span>
-                                    </div>
                                     
                                     <div class="relative group">
                                         <a href="javascript:void(0)" class="block w-full px-4 py-3 text-center bg-green-600 text-white rounded-lg shadow-lg opacity-60 cursor-not-allowed" aria-disabled="true">

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,7 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
 
         // Character Management
         Route::get('/characters', [CharacterController::class, 'index'])->name('characters.index');
+        Route::post('/characters/{character}/unstuck', [CharacterController::class, 'unstuck'])->name('characters.unstuck');
 
         // Tickets
         Route::get('/tickets', [TicketController::class, 'index'])->name('tickets.index');


### PR DESCRIPTION
## Summary
- add `unstuck` method in `CharacterController`
- register `characters.unstuck` route
- show flash messages on character manager
- allow players to unstuck individual characters
- remove disabled "Unstuck Character" option from menu
- add translations for new strings

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b67da080832c8a9d93f6cc96a20f