### PR TITLE
Fix Filament relation manager class

### DIFF
--- a/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
+++ b/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
@@ -8,9 +8,9 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Resources\RelationManagers\HasManyRelationManager;
+use Filament\Resources\RelationManagers\RelationManager;
 
-class MessagesRelationManager extends HasManyRelationManager
+class MessagesRelationManager extends RelationManager
 {
     protected static string $relationship = 'messages';
 


### PR DESCRIPTION
## Summary
- fix the namespace for the MessagesRelationManager

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856b74cb178832cb9b21e26eac91ae1