### PR TITLE
Fix relation manager methods

### DIFF
--- a/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
+++ b/app/Filament/Resources/TicketResource/RelationManagers/MessagesRelationManager.php
@@ -14,7 +14,7 @@ class MessagesRelationManager extends RelationManager
 {
     protected static string $relationship = 'messages';
 
-    public static function form(Form $form): Form
+    public function form(Form $form): Form
     {
         return $form->schema([
             Textarea::make('content')
@@ -23,7 +23,7 @@ class MessagesRelationManager extends RelationManager
         ]);
     }
 
-    public static function table(Table $table): Table
+    public function table(Table $table): Table
     {
         return $table
             ->columns([


### PR DESCRIPTION
## Summary
- make `form()` and `table()` non-static in `MessagesRelationManager`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b84c9d14832cb0c05e6b1f1e7903