### PR TITLE
Add Stripe payment for coins

### DIFF
--- a/app/Filament/Resources/PaymentPackageResource.php
+++ b/app/Filament/Resources/PaymentPackageResource.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PaymentPackageResource\Pages;
+use App\Models\PaymentPackage;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class PaymentPackageResource extends Resource
+{
+    protected static ?string $model = PaymentPackage::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-credit-card';
+
+    protected static ?string $navigationGroup = 'Shop Management';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Section::make('Package Details')->schema([
+                TextInput::make('name')->required(),
+                TextInput::make('coins')->numeric()->required(),
+                TextInput::make('price')->numeric()->required(),
+                TextInput::make('currency')->default('EUR')->maxLength(3),
+                TextInput::make('stripe_price_id')->label('Stripe Price ID'),
+            ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('name')->sortable()->searchable(),
+            TextColumn::make('coins')->sortable(),
+            TextColumn::make('price')->sortable(),
+            TextColumn::make('currency'),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPaymentPackages::route('/'),
+            'create' => Pages\CreatePaymentPackage::route('/create'),
+            'edit' => Pages\EditPaymentPackage::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PaymentPackageResource/Pages/CreatePaymentPackage.php
+++ b/app/Filament/Resources/PaymentPackageResource/Pages/CreatePaymentPackage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PaymentPackageResource\Pages;
+
+use App\Filament\Resources\PaymentPackageResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePaymentPackage extends CreateRecord
+{
+    protected static string $resource = PaymentPackageResource::class;
+}

--- a/app/Filament/Resources/PaymentPackageResource/Pages/EditPaymentPackage.php
+++ b/app/Filament/Resources/PaymentPackageResource/Pages/EditPaymentPackage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PaymentPackageResource\Pages;
+
+use App\Filament\Resources\PaymentPackageResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPaymentPackage extends EditRecord
+{
+    protected static string $resource = PaymentPackageResource::class;
+}

--- a/app/Filament/Resources/PaymentPackageResource/Pages/ListPaymentPackages.php
+++ b/app/Filament/Resources/PaymentPackageResource/Pages/ListPaymentPackages.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PaymentPackageResource\Pages;
+
+use App\Filament\Resources\PaymentPackageResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPaymentPackages extends ListRecords
+{
+    protected static string $resource = PaymentPackageResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Metin2User;
+use App\Models\Payment;
+use App\Models\PaymentPackage;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Stripe\Checkout\Session;
+use Stripe\Stripe;
+
+class PaymentController extends Controller
+{
+    public function index()
+    {
+        $packages = PaymentPackage::all();
+
+        return view('payments.index', compact('packages'));
+    }
+
+    public function checkout(Request $request, PaymentPackage $package)
+    {
+        $user = Auth::guard('metin2')->user();
+
+        Stripe::setApiKey(config('services.stripe.secret'));
+
+        $session = Session::create([
+            'mode' => 'payment',
+            'payment_method_types' => ['card'],
+            'line_items' => [[
+                'price_data' => [
+                    'currency' => $package->currency,
+                    'product_data' => ['name' => $package->name],
+                    'unit_amount' => (int) ($package->price * 100),
+                ],
+                'quantity' => 1,
+            ]],
+            'customer_email' => $user->email,
+            'metadata' => [
+                'user_id' => $user->id,
+                'package_id' => $package->id,
+            ],
+            'success_url' => route('coins.success', [], true).'?session_id={CHECKOUT_SESSION_ID}',
+            'cancel_url' => route('coins.cancel', [], true),
+        ]);
+
+        $payment = Payment::create([
+            'metin2_user_id' => $user->id,
+            'payment_package_id' => $package->id,
+            'stripe_session_id' => $session->id,
+            'amount' => $package->price,
+            'coins' => $package->coins,
+            'ip_address' => $request->ip(),
+        ]);
+
+        return redirect($session->url);
+    }
+
+    public function success(Request $request)
+    {
+        $sessionId = $request->get('session_id');
+        if (! $sessionId) {
+            return redirect()->route('coins.index');
+        }
+
+        Stripe::setApiKey(config('services.stripe.secret'));
+        $session = Session::retrieve($sessionId);
+
+        if ($session->payment_status === 'paid') {
+            $payment = Payment::where('stripe_session_id', $sessionId)->first();
+            if ($payment && $payment->status !== 'paid') {
+                $payment->status = 'paid';
+                $payment->save();
+
+                $user = Metin2User::find($payment->metin2_user_id);
+                if ($user) {
+                    $user->coins += $payment->coins;
+                    $user->save();
+                }
+            }
+        }
+
+        return redirect()->route('coins.index')->with('success', 'Payment successful!');
+    }
+
+    public function cancel()
+    {
+        return redirect()->route('coins.index')->with('error', 'Payment cancelled.');
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    protected $fillable = [
+        'metin2_user_id',
+        'payment_package_id',
+        'stripe_session_id',
+        'status',
+        'amount',
+        'coins',
+        'ip_address',
+    ];
+
+    public function package()
+    {
+        return $this->belongsTo(PaymentPackage::class, 'payment_package_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(Metin2User::class, 'metin2_user_id');
+    }
+}

--- a/app/Models/PaymentPackage.php
+++ b/app/Models/PaymentPackage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentPackage extends Model
+{
+    protected $fillable = [
+        'name',
+        'coins',
+        'price',
+        'currency',
+        'stripe_price_id',
+    ];
+}

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,9 @@ return [
         ],
     ],
 
+    'stripe' => [
+        'secret' => env('STRIPE_SECRET'),
+        'public' => env('STRIPE_PUBLIC'),
+    ],
+
 ];

--- a/database/migrations/2025_12_01_000000_create_payment_packages_table.php
+++ b/database/migrations/2025_12_01_000000_create_payment_packages_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_packages', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('coins');
+            $table->decimal('price', 8, 2);
+            $table->string('currency', 3)->default('EUR');
+            $table->string('stripe_price_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_packages');
+    }
+};

--- a/database/migrations/2025_12_01_000001_create_payments_table.php
+++ b/database/migrations/2025_12_01_000001_create_payments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('metin2_user_id');
+            $table->unsignedBigInteger('payment_package_id');
+            $table->string('stripe_session_id')->nullable();
+            $table->string('status')->default('pending');
+            $table->decimal('amount', 8, 2);
+            $table->integer('coins');
+            $table->string('ip_address', 45)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -196,6 +196,10 @@
                                 <button id="open-itemshop" class="w-full px-4 py-3 text-center rounded-lg shadow-lg transition-all duration-300 transform hover:scale-105 glow-button bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-500 hover:to-orange-500" aria-label="Open Item Shop">
                                     🛒 Item-Shop
                                 </button>
+
+                                <a href="{{ route('coins.index') }}" class="block w-full px-4 py-3 text-center bg-green-600 hover:bg-green-500 text-white rounded-lg shadow-lg transition-all duration-300 transform hover:scale-105 glow-button" aria-label="Add Coins">
+                                    ➕ Add Coins
+                                </a>
                                 
                                 <!-- Change Password -->
                                 <a href="{{ route('password.change') }}" class="block w-full px-4 py-3 text-center bg-blue-600 hover:bg-blue-500 text-white rounded-lg shadow-lg transition-all duration-300 transform hover:scale-105 glow-button" aria-label="Change Password">

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -1,0 +1,22 @@
+@extends('itemshop.layouts.app')
+
+@section('title', 'Add Coins')
+
+@section('content')
+    <h2 class="text-lg font-bold text-yellow-400 mb-3">Select Package</h2>
+    <div class="grid grid-cols-1 gap-4">
+        @foreach($packages as $package)
+            <form action="{{ route('coins.checkout', $package) }}" method="POST" class="bg-gray-700 p-4 rounded-lg flex justify-between items-center">
+                @csrf
+                <div>
+                    <div class="font-semibold">{{ $package->name }}</div>
+                    <div class="text-sm text-gray-400">{{ $package->coins }} Coins</div>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-yellow-400 font-bold">{{ number_format($package->price,2) }} {{ $package->currency }}</span>
+                    <button class="px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded">Buy</button>
+                </div>
+            </form>
+        @endforeach
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\PlayerController;
 use App\Http\Controllers\RegisterController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\WelcomeController;
+use App\Http\Controllers\PaymentController;
 use App\Http\Middleware\LanguageMiddleware;
 use Illuminate\Support\Facades\Route;
 
@@ -79,6 +80,12 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
         // Item Shop
         Route::get('/itemshop', [ItemShopController::class, 'index'])->name('itemshop');
         Route::get('/itemshop/category/{slug}', [CategoryController::class, 'show'])->name('categories.show');
+
+        // Add Coins
+        Route::get('/coins', [PaymentController::class, 'index'])->name('coins.index');
+        Route::post('/coins/checkout/{package}', [PaymentController::class, 'checkout'])->name('coins.checkout');
+        Route::get('/coins/success', [PaymentController::class, 'success'])->name('coins.success');
+        Route::get('/coins/cancel', [PaymentController::class, 'cancel'])->name('coins.cancel');
 
         // Character Management
         Route::get('/characters', [CharacterController::class, 'index'])->name('characters.index');

--- a/tests/Feature/PaymentPackageTest.php
+++ b/tests/Feature/PaymentPackageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PaymentPackage;
+use Tests\TestCase;
+
+class PaymentPackageTest extends TestCase
+{
+    public function test_package_creation(): void
+    {
+        $package = PaymentPackage::create([
+            'name' => 'Small Pack',
+            'coins' => 100,
+            'price' => 9.99,
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertDatabaseHas('payment_packages', [
+            'id' => $package->id,
+            'coins' => 100,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce PaymentPackage Filament resource to manage coin bundles
- enable Stripe settings
- allow players to buy coins using Stripe Checkout
- provide migrations and models for payments
- add "Add Coins" user button
- cover package creation with a test

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6856b70edfbc832cacea795f30951fe3