### PR TITLE
Add Stripe payment settings page in Filament

### DIFF
--- a/app/Filament/Pages/PaymentSettings.php
+++ b/app/Filament/Pages/PaymentSettings.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Forms; 
+use Filament\Pages\Page; 
+use Filament\Forms\Components\TextInput; 
+use App\Models\Setting; 
+
+class PaymentSettings extends Page implements Forms\Contracts\HasForms
+{
+    use Forms\Concerns\InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-credit-card';
+    protected static ?string $navigationGroup = 'Settings';
+    protected static ?string $navigationLabel = 'Payment';
+    protected static ?string $title = 'Payment Settings';
+    protected static ?string $slug = 'settings/payment';
+    protected static string $view = 'filament.pages.payment-settings';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'stripe_public_key' => Setting::getValue('stripe_public_key'),
+            'stripe_secret_key' => Setting::getValue('stripe_secret_key'),
+        ]);
+    }
+
+    protected function getFormSchema(): array
+    {
+        return [
+            TextInput::make('stripe_public_key')
+                ->label('Stripe Public Key')
+                ->required(),
+            TextInput::make('stripe_secret_key')
+                ->label('Stripe Secret Key')
+                ->required(),
+        ];
+    }
+
+    public function submit(): void
+    {
+        $data = $this->form->getState();
+
+        Setting::updateOrCreate(
+            ['key' => 'stripe_public_key'],
+            ['value' => $data['stripe_public_key']]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'stripe_secret_key'],
+            ['value' => $data['stripe_secret_key']]
+        );
+
+        $this->notify('success', 'Stripe settings updated.');
+    }
+}

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -23,7 +23,7 @@ class PaymentController extends Controller
     {
         $user = Auth::guard('metin2')->user();
 
-        Stripe::setApiKey(config('services.stripe.secret'));
+        Stripe::setApiKey(\App\Models\Setting::getValue('stripe_secret_key', config('services.stripe.secret')));
 
         $session = Session::create([
             'mode' => 'payment',
@@ -64,7 +64,7 @@ class PaymentController extends Controller
             return redirect()->route('coins.index');
         }
 
-        Stripe::setApiKey(config('services.stripe.secret'));
+        Stripe::setApiKey(\App\Models\Setting::getValue('stripe_secret_key', config('services.stripe.secret')));
         $session = Session::retrieve($sessionId);
 
         if ($session->payment_status === 'paid') {

--- a/resources/views/filament/pages/payment-settings.blade.php
+++ b/resources/views/filament/pages/payment-settings.blade.php
@@ -1,0 +1,8 @@
+<x-filament-panels::page>
+    <form wire:submit.prevent="submit" class="space-y-6">
+        {{ $this->form }}
+        <x-filament::button type="submit">
+            Save
+        </x-filament::button>
+    </form>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- add `PaymentSettings` page for Stripe keys in Filament
- store Stripe keys in settings table
- read Stripe secret key from settings in `PaymentController`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856bbb04268832ca7487b973e930979