### PR TITLE
Add comment system for events

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -3,6 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\Event;
+use App\Models\EventComment;
+use App\Models\Reaction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class EventController extends Controller
 {
@@ -10,5 +15,70 @@ class EventController extends Controller
     {
         $events = Event::orderBy('start_date', 'desc')->get();
         return view('events.index', compact('events'));
+    }
+
+    public function show(Event $event)
+    {
+        $comments = $event->comments()->latest()->get();
+        return view('events.show', compact('event', 'comments'));
+    }
+
+    public function comment(Request $request, Event $event)
+    {
+        $request->validate([
+            'content' => 'required|string',
+        ]);
+
+        $event->comments()->create([
+            'author' => $request->input('author'),
+            'content' => $request->input('content'),
+        ]);
+
+        return redirect()->back();
+    }
+
+    public function like(EventComment $comment)
+    {
+        $this->react($comment, true);
+        return redirect()->back();
+    }
+
+    public function dislike(EventComment $comment)
+    {
+        $this->react($comment, false);
+        return redirect()->back();
+    }
+
+    private function react(Model $model, bool $like): void
+    {
+        if (!Auth::guard('metin2')->check()) {
+            return;
+        }
+
+        $user = Auth::guard('metin2')->user();
+
+        $reaction = $model->reactions()->where('user_id', $user->id)->first();
+        $type = $like ? 'like' : 'dislike';
+
+        if (!$reaction) {
+            $model->reactions()->create(['user_id' => $user->id, 'reaction' => $type]);
+            $model->increment($like ? 'likes' : 'dislikes');
+            return;
+        }
+
+        if ($reaction->reaction === $type) {
+            return;
+        }
+
+        $reaction->reaction = $type;
+        $reaction->save();
+
+        if ($like) {
+            $model->increment('likes');
+            $model->decrement('dislikes');
+        } else {
+            $model->increment('dislikes');
+            $model->decrement('likes');
+        }
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\EventComment;
+use App\Models\Reaction;
 
 class Event extends Model
 {
@@ -20,4 +22,14 @@ class Event extends Model
         'start_date' => 'datetime',
         'end_date' => 'datetime',
     ];
+
+    public function comments()
+    {
+        return $this->hasMany(EventComment::class);
+    }
+
+    public function reactions()
+    {
+        return $this->morphMany(Reaction::class, 'reactionable');
+    }
 }

--- a/app/Models/EventComment.php
+++ b/app/Models/EventComment.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EventComment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['event_id', 'author', 'content', 'likes', 'dislikes'];
+
+    public function event()
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    public function reactions()
+    {
+        return $this->morphMany(Reaction::class, 'reactionable');
+    }
+}

--- a/database/migrations/2025_09_04_000000_create_event_comments_table.php
+++ b/database/migrations/2025_09_04_000000_create_event_comments_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('event_comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->string('author')->nullable();
+            $table->text('content');
+            $table->unsignedInteger('likes')->default(0);
+            $table->unsignedInteger('dislikes')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('event_comments');
+    }
+};

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -23,13 +23,16 @@
                 }
             @endphp
             <li class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700 border-l-4 {{ $alertClass }}">
-                <h3 class="font-bold text-yellow-400 text-lg">{{ $event->title }}</h3>
+                <h3 class="font-bold text-yellow-400 text-lg">
+                    <a href="{{ route('events.show', $event) }}" class="hover:underline">{{ $event->title }}</a>
+                </h3>
                 <p class="text-gray-300 text-sm">{{ $event->start_date->format('Y-m-d H:i') }}</p>
                 <p class="{{ $textClass }} text-sm font-semibold">{{ $timeText }}</p>
                 @if($event->description)
                     <div class="mt-2 text-gray-300 prose prose-invert max-w-none">
                         {!! $event->description !!}
                     </div>
+                    <a href="{{ route('events.show', $event) }}" class="text-green-400 text-sm hover:underline">{{ __('messages.read_more') }}</a>
                 @endif
             </li>
         @endforeach

--- a/resources/views/events/show.blade.php
+++ b/resources/views/events/show.blade.php
@@ -1,0 +1,41 @@
+@extends('layout')
+
+@section('title', $event->title)
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
+    <h2 class="text-2xl font-bold mb-2 text-green-400">{{ $event->title }}</h2>
+    <p class="text-gray-300 mb-4">{{ $event->start_date->format('Y-m-d H:i') }}</p>
+    @if($event->description)
+        <div class="prose prose-invert max-w-none text-gray-300">{!! $event->description !!}</div>
+    @endif
+</div>
+
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    <h3 class="text-lg font-semibold mb-4 text-green-400">{{ __('messages.comments') }}</h3>
+    <form action="{{ route('events.comment', $event) }}" method="POST" class="mb-4">
+        @csrf
+        <input type="text" name="author" placeholder="{{ __('messages.your_name') }}" class="w-full mb-2 p-2 bg-gray-800 text-white rounded" />
+        <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+        <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
+    </form>
+
+    <div class="space-y-4">
+        @foreach ($comments as $comment)
+            <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
+                <p class="text-sm text-gray-300">{{ $comment->content }}</p>
+                <div class="text-xs text-gray-500 mt-2 flex items-center gap-2">
+                    <form action="{{ route('events.comments.like', $comment) }}" method="POST" class="inline">
+                        @csrf
+                        <button>👍 {{ $comment->likes }}</button>
+                    </form>
+                    <form action="{{ route('events.comments.dislike', $comment) }}" method="POST" class="inline">
+                        @csrf
+                        <button>👎 {{ $comment->dislikes }}</button>
+                    </form>
+                </div>
+            </div>
+        @endforeach
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,10 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
 
     Route::get('/page/{slug}', [PageController::class, 'show'])->name('page.show');
     Route::get('/events', [EventController::class, 'index'])->name('events.index');
+    Route::get('/events/{event}', [EventController::class, 'show'])->name('events.show');
+    Route::post('/events/{event}/comment', [EventController::class, 'comment'])->name('events.comment');
+    Route::post('/events/comments/{comment}/like', [EventController::class, 'like'])->name('events.comments.like');
+    Route::post('/events/comments/{comment}/dislike', [EventController::class, 'dislike'])->name('events.comments.dislike');
 
     // Contact
     Route::get('/contact', [ContactController::class, 'show'])->name('contact.show');


### PR DESCRIPTION
## Summary
- allow commenting and reacting on events
- create `EventComment` model and migration
- wire up comments and reactions in `Event` model and controller
- add event comment routes and views
- link to event details from events index

## Testing
- `composer test` *(fails: composer/php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856bca18628832c9dcb437823d96ea0