### PR TITLE
Add auto-close for inactive tickets

### DIFF
--- a/app/Console/Commands/CloseInactiveTickets.php
+++ b/app/Console/Commands/CloseInactiveTickets.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Ticket;
+
+class CloseInactiveTickets extends Command
+{
+    protected $signature = 'tickets:close-inactive';
+
+    protected $description = 'Close tickets with no activity for a week';
+
+    public function handle(): int
+    {
+        $cutoff = now()->subWeek();
+
+        $tickets = Ticket::where('status', 'open')
+            ->whereDoesntHave('messages', function ($query) use ($cutoff) {
+                $query->where('created_at', '>=', $cutoff);
+            })
+            ->get();
+
+        foreach ($tickets as $ticket) {
+            $ticket->update(['status' => 'closed']);
+            $this->info("Closed ticket ID {$ticket->id}");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('tickets:close-inactive')->daily();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+
+        require base_path('routes/console.php');
+    }
+}


### PR DESCRIPTION
## Summary
- add command to close old tickets
- schedule command in console kernel

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bd07a660832c83dd4e6776fc1663