### PR TITLE
Implement real server status feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,8 @@ MAIL_FROM_ADDRESS=hello@example.com
 MAIL_FROM_NAME="Play-Metin2"
 
 FILAMENT_FILESYSTEM_DISK=public
+
+# Metin2 server connection used for server status
+METIN2_SERVER_HOST=127.0.0.1
+METIN2_SERVER_PORT=13000
+METIN2_SERVER_TIMEOUT=1

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -1,0 +1,40 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class ServerController extends Controller
+{
+    public function status(): JsonResponse
+    {
+        $host = config('server.host');
+        $port = config('server.port');
+        $timeout = config('server.timeout', 1);
+
+        $online = false;
+        $connection = @fsockopen($host, $port, $errno, $errstr, $timeout);
+        if ($connection) {
+            $online = true;
+            fclose($connection);
+        }
+
+        $playersOnline = null;
+        try {
+            $schema = DB::connection('player')->getSchemaBuilder();
+            if ($schema->hasColumn('player', 'is_login')) {
+                $playersOnline = DB::connection('player')->table('player')->where('is_login', 1)->count();
+            } elseif ($schema->hasColumn('player', 'is_online')) {
+                $playersOnline = DB::connection('player')->table('player')->where('is_online', 1)->count();
+            }
+        } catch (\Throwable $e) {
+            $playersOnline = null;
+        }
+
+        return response()->json([
+            'online' => $online,
+            'players_online' => $playersOnline,
+            'uptime' => null,
+        ]);
+    }
+}

--- a/config/server.php
+++ b/config/server.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'host' => env('METIN2_SERVER_HOST', '127.0.0.1'),
+    'port' => env('METIN2_SERVER_PORT', 13000),
+    'timeout' => env('METIN2_SERVER_TIMEOUT', 1),
+];

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -303,18 +303,18 @@
                     </div>
                     <div class="p-4 text-center">
                         <div class="inline-block px-4 py-2 mb-4 bg-black bg-opacity-30 rounded-full">
-                            <span class="inline-block w-3 h-3 bg-green-500 rounded-full mr-2 animate-pulse"></span>
-                            <span class="text-green-400 font-bold">Online</span>
+                            <span id="server-status-indicator" class="inline-block w-3 h-3 rounded-full mr-2 bg-gray-500"></span>
+                            <span id="server-status-text" class="text-gray-400 font-bold">...</span>
                         </div>
-                        
+
                         <div class="grid grid-cols-2 gap-4 mb-4">
                             <div class="bg-black bg-opacity-30 rounded-lg p-3">
-                                <div class="text-xl font-bold text-green-400">3232</div>
+                                <div id="server-players-online" class="text-xl font-bold text-gray-400">-</div>
                                 <div class="text-xs text-gray-400">{{ __('messages.sidebar_right_server_players_online') }}</div>
                             </div>
-                            
+
                             <div class="bg-black bg-opacity-30 rounded-lg p-3">
-                                <div class="text-xl font-bold text-yellow-400">232h</div>
+                                <div id="server-uptime" class="text-xl font-bold text-gray-400">-</div>
                                 <div class="text-xs text-gray-400">{{ __('messages.sidebar_right_server_uptime') }}</div>
                             </div>
                         </div>
@@ -376,6 +376,46 @@
 <!-- JavaScript pentru funcționalitatea site-ului -->
 <script>
     document.addEventListener("DOMContentLoaded", function () {
+        // Fetch real server status and update sidebar
+        fetch('/server-status')
+            .then(response => response.json())
+            .then(data => {
+                const indicator = document.getElementById('server-status-indicator');
+                const statusText = document.getElementById('server-status-text');
+                const playersOnline = document.getElementById('server-players-online');
+                const uptime = document.getElementById('server-uptime');
+
+                if (data.online) {
+                    indicator?.classList.add('bg-green-500', 'animate-pulse');
+                    indicator?.classList.remove('bg-red-500');
+                    statusText.textContent = 'Online';
+                    statusText.classList.add('text-green-400');
+                    statusText.classList.remove('text-red-400');
+                } else {
+                    indicator?.classList.add('bg-red-500');
+                    indicator?.classList.remove('bg-green-500', 'animate-pulse');
+                    statusText.textContent = 'Offline';
+                    statusText.classList.add('text-red-400');
+                    statusText.classList.remove('text-green-400');
+                }
+
+                if (playersOnline && data.players_online !== null) {
+                    playersOnline.textContent = data.players_online;
+                    playersOnline.classList.add('text-green-400');
+                }
+
+                if (uptime && data.uptime) {
+                    uptime.textContent = data.uptime;
+                    uptime.classList.add('text-yellow-400');
+                }
+            })
+            .catch(() => {
+                const indicator = document.getElementById('server-status-indicator');
+                const statusText = document.getElementById('server-status-text');
+                indicator?.classList.add('bg-red-500');
+                statusText.textContent = 'Offline';
+                statusText.classList.add('text-red-400');
+            });
         // Language dropdown toggle
         const langButton = document.getElementById("lang-button");
         const langDropdown = document.getElementById("lang-dropdown");

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\PlayerController;
 use App\Http\Controllers\RegisterController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\WelcomeController;
+use App\Http\Controllers\ServerController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Middleware\LanguageMiddleware;
 use Illuminate\Support\Facades\Route;
@@ -102,5 +103,8 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
     Route::get('/check-auth', function () {
         return response()->json(['authenticated' => session()->has('metin2_user')]);
     });
+
+    // Server status endpoint for AJAX polling
+    Route::get('/server-status', [ServerController::class, 'status'])->name('server.status');
 
 });


### PR DESCRIPTION
## Summary
- add new `ServerController` with status endpoint
- add server connection config and example env vars
- update routes to expose `/server-status`
- make sidebar server status widget dynamic via JS

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bd20c1c0832ca6e02bf8272ba337