### PR TITLE
Add player and guild profile pages

### DIFF
--- a/app/Http/Controllers/GuildController.php
+++ b/app/Http/Controllers/GuildController.php
@@ -58,6 +58,34 @@ class GuildController extends Controller
         return view('top-guilds', [
             'guilds' => $guilds,
             'title' => 'Top Guilds'
-        ]);        
+        ]);
+    }
+
+    public function show($name)
+    {
+        $guild = DB::connection('player')
+            ->table('guild')
+            ->select('id', 'name', 'level', 'ladder_point', 'win', 'loss', 'gold')
+            ->where('name', $name)
+            ->first();
+
+        if (!$guild) {
+            abort(404);
+        }
+
+        $members = DB::connection('player')
+            ->table('guild_member as gm')
+            ->join('player as p', 'gm.pid', '=', 'p.id')
+            ->select('p.name', 'p.level')
+            ->where('gm.guild_id', $guild->id)
+            ->orderByDesc('p.level')
+            ->limit(20)
+            ->get();
+
+        return view('guild-profile', [
+            'guild' => $guild,
+            'members' => $members,
+            'title' => $guild->name,
+        ]);
     }
 }

--- a/resources/views/guild-profile.blade.php
+++ b/resources/views/guild-profile.blade.php
@@ -1,0 +1,23 @@
+@extends('layout')
+
+@section('title', $title)
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 space-y-4">
+    <h2 class="text-2xl font-semibold text-green-400">{{ $guild->name }}</h2>
+    <div class="grid grid-cols-2 gap-4 text-white">
+        <div><strong>Level:</strong> {{ $guild->level }}</div>
+        <div><strong>Points:</strong> {{ $guild->ladder_point }}</div>
+        <div><strong>Wins:</strong> {{ $guild->win }}</div>
+        <div><strong>Losses:</strong> {{ $guild->loss }}</div>
+        <div><strong>Gold:</strong> {{ number_format($guild->gold) }}</div>
+    </div>
+
+    <h3 class="text-xl font-semibold text-green-300 mt-4">Members</h3>
+    <ul class="list-disc list-inside space-y-1">
+        @foreach($members as $member)
+            <li>{{ $member->name }} ({{ $member->level }})</li>
+        @endforeach
+    </ul>
+</div>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -110,7 +110,11 @@
                             @foreach ($players as $player)
                                 <li class="flex justify-between py-2 px-2 hover:bg-gray-900 transition text-white rounded-md">
                                     <span class="w-1/6 text-center text-yellow-400 font-bold">#{{ $player->rank }}</span>
-                                    <span class="w-2/6 text-center text-gray-100">{{ e($player->player_name) }}</span>
+                                    <span class="w-2/6 text-center text-gray-100">
+                                        <a href="{{ route('player.show', $player->player_name) }}" class="hover:underline">
+                                            {{ e($player->player_name) }}
+                                        </a>
+                                    </span>
                                     <span class="w-1/6 text-center">{{ $player->level }}</span>
                                 </li>
                             @endforeach
@@ -138,7 +142,11 @@
                             @foreach ($guilds as $index => $guild)
                                 <li class="flex justify-between py-2 px-2 hover:bg-gray-900 transition text-white rounded-md">
                                     <span class="w-1/6 text-center font-bold text-blue-400">#{{ $index + 1 }}</span>
-                                    <span class="w-2/6 text-center text-yellow-400 font-bold truncate" title="{{ e($guild->name) }}">{{ e($guild->name) }}</span>
+                                    <span class="w-2/6 text-center text-yellow-400 font-bold truncate" title="{{ e($guild->name) }}">
+                                        <a href="{{ route('guild.show', $guild->name) }}" class="hover:underline">
+                                            {{ e($guild->name) }}
+                                        </a>
+                                    </span>
                                     <span class="w-1/6 text-center">{{ $guild->level }}</span>
                                 </li>
                             @endforeach

--- a/resources/views/player-profile.blade.php
+++ b/resources/views/player-profile.blade.php
@@ -1,0 +1,17 @@
+@extends('layout')
+
+@section('title', $title)
+
+@section('content')
+<div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
+    <h2 class="text-2xl font-semibold mb-4 text-green-400">{{ $player->player_name }}</h2>
+    <div class="grid grid-cols-2 gap-4 text-white">
+        <div><strong>Level:</strong> {{ $player->level }}</div>
+        <div><strong>Empire:</strong> {{ $player->empire }}</div>
+        <div><strong>Guild:</strong> {{ $player->guild_name }}</div>
+        <div><strong>Playtime:</strong> {{ $player->playtime }} minutes</div>
+        <div><strong>Killed Monsters:</strong> {{ $player->killed_monster }}</div>
+        <div><strong>Golden Bars:</strong> {{ $player->golden_bars }}</div>
+    </div>
+</div>
+@endsection

--- a/resources/views/top-guilds.blade.php
+++ b/resources/views/top-guilds.blade.php
@@ -55,7 +55,11 @@
                 @foreach($guilds as $index => $guild)
                     <tr class="border-b border-gray-600">
                         <td class="p-2">{{ $index + 1 }}</td>
-                        <td class="p-2 text-yellow-400 font-bold">{{ e($guild->name) }}</td>
+                        <td class="p-2 text-yellow-400 font-bold">
+                            <a href="{{ route('guild.show', $guild->name) }}" class="hover:underline">
+                                {{ e($guild->name) }}
+                            </a>
+                        </td>
                         <td class="p-2">{{ $guild->level }}</td>
                         <td class="p-2">{{ $guild->ladder_point }}</td>
                         <td class="p-2">{{ $guild->win }}</td>

--- a/resources/views/top-players.blade.php
+++ b/resources/views/top-players.blade.php
@@ -48,7 +48,11 @@
                 @foreach($players as $player)
                     <tr class="border-b border-gray-600">
                         <td class="p-2">{{ $player->rank }}</td>
-                        <td class="p-2">{{ $player->player_name }}</td>
+                        <td class="p-2">
+                            <a href="{{ route('player.show', $player->player_name) }}" class="text-green-400 hover:underline">
+                                {{ $player->player_name }}
+                            </a>
+                        </td>
                         <td class="p-2">{{ $player->level }}</td>
 						<td class="p-2 text-center">
 							@if($player->empire == 3)
@@ -80,9 +84,15 @@
 								</div>
 							@endif
 						</td>
-						<td class="p-2">
-							{{ $player->guild_name }}
-						</td>
+                                                <td class="p-2">
+                                                    @if($player->guild_name !== 'N/A')
+                                                        <a href="{{ route('guild.show', $player->guild_name) }}" class="text-blue-400 hover:underline">
+                                                            {{ $player->guild_name }}
+                                                        </a>
+                                                    @else
+                                                        {{ $player->guild_name }}
+                                                    @endif
+                                                </td>
 
 						<td class="p-2">{{ $player->playtime }} {{ __('messages.page_top_players_table_play_time_minutes') }}</td>
 						<td class="p-2">{{ $player->killed_monster }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,8 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
     Route::get('/', [WelcomeController::class, 'index'])->name('index');
     Route::get('/top-players', [PlayerController::class, 'topPlayers'])->name('top.players');
     Route::get('/top-guilds', [GuildController::class, 'topGuilds'])->name('top.guilds');
+    Route::get('/player/{name}', [PlayerController::class, 'show'])->name('player.show');
+    Route::get('/guild/{name}', [GuildController::class, 'show'])->name('guild.show');
     Route::get('/register', [RegisterController::class, 'showRegisterForm'])->name('register.form');
     Route::post('/register', [RegisterController::class, 'register'])->name('register.submit');
 


### PR DESCRIPTION
## Summary
- add routes for player and guild profiles
- implement `show` methods in `PlayerController` and `GuildController`
- create blade views for player and guild profiles
- link player and guild names to their profile pages in sidebars and rankings

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856bd5cbc28832cbb3daaf22c0d0556