### PR TITLE
Remove Guides from menu

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -52,7 +52,6 @@
                                 <li><a href="/events" class="text-white hover:text-green-400 glow-link py-2">{{ __('messages.menu_events') }}</a></li>
                                 <li><a href="/top-players" class="text-white hover:text-green-400 glow-link py-2">Rankings</a></li>
                                 <li><a href="/tickets" class="text-white hover:text-green-400 glow-link py-2">{{ __('messages.menu_tickets') }}</a></li>
-                                <li><a href="/guides" class="text-white hover:text-green-400 glow-link py-2">Guides</a></li>
                             </ul>
                             
                             <!-- Language Switcher -->
@@ -98,7 +97,6 @@
                     <a href="/events" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">{{ __('messages.menu_events') }}</a>
                     <a href="/top-players" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">Rankings</a>
                     <a href="/tickets" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">{{ __('messages.menu_tickets') }}</a>
-                    <a href="/guides" class="block px-3 py-2 rounded-md hover:bg-gray-700 transition">Guides</a>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## Summary
- remove Guides from main and mobile menus

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c79e3680832c96e45a19d30047c5