### PR TITLE
Show Filament logger under Logs

### DIFF
--- a/resources/lang/vendor/filament-logger/en/messages.php
+++ b/resources/lang/vendor/filament-logger/en/messages.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+    "title" => "Activity Log",
+    "group" => "Logs",
+    "single" => "Activity",
+    "columns" => [
+        "model" => "Model",
+        "response_time" => "Response Time",
+        "status" => "Status",
+        "method" => "Method",
+        "url" => "URL",
+        "referer" => "Referer",
+        "query" => "Query",
+        "remote_address" => "Remote Address",
+        "user_agent" => "User Agent",
+        "response" => "Response",
+        "level" => "Level",
+        "user" => "User",
+        "log" => "Log",
+        "created_at" => "Created At",
+        "updated_at" => "Updated At"
+    ],
+    "actions" => [
+        "clear" => [
+            "label" => "Clear Activities",
+            "success" => [
+                "title" => "Activities Cleared",
+                "body" => "All activities have been cleared."
+            ],
+        ],
+        "poll" => [
+            "label" => "Realtime Poll",
+            "enabled" => [
+                "title" => "Polling Enabled",
+                "body" => "Activities will be polled every 2 seconds."
+            ],
+            "disabled" => [
+                "title" => "Polling Disabled",
+                "body" => "Activities will no longer be polled."
+            ]
+        ]
+    ]
+];

--- a/resources/lang/vendor/filament-logger/ro/messages.php
+++ b/resources/lang/vendor/filament-logger/ro/messages.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+    "title" => "Jurnal Activitate",
+    "group" => "Jurnale",
+    "single" => "Activitate",
+    "columns" => [
+        "model" => "Model",
+        "response_time" => "Response Time",
+        "status" => "Status",
+        "method" => "Method",
+        "url" => "URL",
+        "referer" => "Referer",
+        "query" => "Query",
+        "remote_address" => "Remote Address",
+        "user_agent" => "User Agent",
+        "response" => "Response",
+        "level" => "Level",
+        "user" => "User",
+        "log" => "Log",
+        "created_at" => "Created At",
+        "updated_at" => "Updated At"
+    ],
+    "actions" => [
+        "clear" => [
+            "label" => "Clear Activities",
+            "success" => [
+                "title" => "Activities Cleared",
+                "body" => "All activities have been cleared."
+            ],
+        ],
+        "poll" => [
+            "label" => "Realtime Poll",
+            "enabled" => [
+                "title" => "Polling Enabled",
+                "body" => "Activities will be polled every 2 seconds."
+            ],
+            "disabled" => [
+                "title" => "Polling Disabled",
+                "body" => "Activities will no longer be polled."
+            ]
+        ]
+    ]
+];


### PR DESCRIPTION
## Summary
- add en and ro translations for Filament logger plugin
- group the Activity Log resource under **Logs** instead of **Settings**

## Testing
- `phpunit` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c9bb3f0c832c9a32d90dfa3ccf32