### PR TITLE
Remove admin-only checks in Filament resources

### DIFF
--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -147,6 +147,6 @@ class AccountResource extends Resource
 
     public static function canViewAny(): bool
     {
-        return auth()->user()?->hasAnyRole(['admin', 'moderator']);
+        return true;
     }
 }

--- a/app/Filament/Resources/AuditLogResource.php
+++ b/app/Filament/Resources/AuditLogResource.php
@@ -52,6 +52,6 @@ class AuditLogResource extends Resource
 
     public static function canViewAny(): bool
     {
-        return auth()->user()?->hasRole('admin');
+        return true;
     }
 }

--- a/app/Filament/Resources/LoginLogResource.php
+++ b/app/Filament/Resources/LoginLogResource.php
@@ -56,6 +56,6 @@ class LoginLogResource extends Resource
 
     public static function canViewAny(): bool
     {
-        return auth()->user()?->hasRole('admin');
+        return true;
     }
 }

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -81,6 +81,6 @@ class SessionResource extends Resource
 
     public static function canViewAny(): bool
     {
-        return auth()->user()?->hasAnyRole(['admin']); // Doar adminii și moderatorii pot vedea sesiunile
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- remove `hasRole('admin')` checks in Filament resources so pages are visible for any authenticated user

## Testing
- `composer test` *(fails: could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_6856cabf1964832ca9d057faa954113e