### PR TITLE
Add gallery reactions and view counts

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -20,18 +20,23 @@ class GalleryController extends Controller
 
     public function show(GalleryItem $item)
     {
+        $item->increment('views');
         $comments = $item->comments()->latest()->get();
         return view('gallery.show', compact('item', 'comments'));
     }
 
     public function comment(Request $request, GalleryItem $item)
     {
+        if (!Auth::guard('metin2')->check()) {
+            return redirect()->back()->with('error', __('messages.error_not_authenticated'));
+        }
+
         $request->validate([
             'content' => 'required|string',
         ]);
 
         $item->comments()->create([
-            'author' => $request->input('author'),
+            'author' => Auth::guard('metin2')->user()->login,
             'content' => $request->input('content'),
         ]);
 
@@ -47,6 +52,18 @@ class GalleryController extends Controller
     public function dislike(GalleryComment $comment)
     {
         $this->react($comment, false);
+        return redirect()->back();
+    }
+
+    public function likeItem(GalleryItem $item)
+    {
+        $this->react($item, true);
+        return redirect()->back();
+    }
+
+    public function dislikeItem(GalleryItem $item)
+    {
+        $this->react($item, false);
         return redirect()->back();
     }
 

--- a/app/Models/GalleryItem.php
+++ b/app/Models/GalleryItem.php
@@ -4,15 +4,29 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Reaction;
 
 class GalleryItem extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['title', 'image_path', 'video_url'];
+    protected $fillable = [
+        'title',
+        'image_path',
+        'video_url',
+        'author',
+        'views',
+        'likes',
+        'dislikes',
+    ];
 
     public function comments()
     {
         return $this->hasMany(GalleryComment::class);
+    }
+
+    public function reactions()
+    {
+        return $this->morphMany(Reaction::class, 'reactionable');
     }
 }

--- a/database/migrations/2025_09_05_000000_add_meta_to_gallery_items_table.php
+++ b/database/migrations/2025_09_05_000000_add_meta_to_gallery_items_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('gallery_items', function (Blueprint $table) {
+            $table->string('author')->nullable();
+            $table->unsignedBigInteger('views')->default(0);
+            $table->unsignedInteger('likes')->default(0);
+            $table->unsignedInteger('dislikes')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('gallery_items', function (Blueprint $table) {
+            $table->dropColumn(['author', 'views', 'likes', 'dislikes']);
+        });
+    }
+};

--- a/resources/views/gallery/show.blade.php
+++ b/resources/views/gallery/show.blade.php
@@ -4,7 +4,23 @@
 
 @section('content')
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700 mb-6">
-    <h2 class="text-2xl font-bold mb-4 text-green-400">{{ $item->title }}</h2>
+    <h2 class="text-2xl font-bold mb-1 text-green-400">{{ $item->title }}</h2>
+    <div class="text-xs text-gray-400 mb-4">
+        @if($item->author)
+            {{ __('messages.posted_by') }} {{ $item->author }} ·
+        @endif
+        {{ $item->created_at->format('M d, Y') }} · {{ $item->views }} views · {{ $comments->count() }} comments
+        <span class="ml-2">
+            <form action="{{ route('gallery.like', $item) }}" method="POST" class="inline">
+                @csrf
+                <button type="submit">👍 {{ $item->likes }}</button>
+            </form>
+            <form action="{{ route('gallery.dislike', $item) }}" method="POST" class="inline ml-2">
+                @csrf
+                <button type="submit">👎 {{ $item->dislikes }}</button>
+            </form>
+        </span>
+    </div>
     @if ($item->image_path)
         <img src="{{ asset('storage/' . $item->image_path) }}" class="w-full rounded" />
     @elseif ($item->video_url)
@@ -16,12 +32,21 @@
 
 <div class="glassmorphism p-6 rounded-lg shadow-lg border border-gray-700">
     <h3 class="text-lg font-semibold mb-4 text-green-400">{{ __('messages.comments') }}</h3>
-    <form action="{{ route('gallery.comment', $item) }}" method="POST" class="mb-4">
-        @csrf
-        <input type="text" name="author" placeholder="{{ __('messages.your_name') }}" class="w-full mb-2 p-2 bg-gray-800 text-white rounded" />
-        <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
-        <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
-    </form>
+    @if(Auth::guard('metin2')->check())
+        <form action="{{ route('gallery.comment', $item) }}" method="POST" class="mb-4">
+            @csrf
+            <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+            <button class="mt-2 px-4 py-2 bg-green-600 text-white rounded">{{ __('messages.submit') }}</button>
+        </form>
+    @else
+        <div class="relative mb-4">
+            <textarea class="w-full p-2 bg-gray-800 text-white rounded h-32" disabled></textarea>
+            <div class="absolute inset-0 flex items-center justify-center">
+                <p class="bg-black bg-opacity-75 text-white p-4 rounded">{{ __('messages.news_comment_login_required') }}</p>
+            </div>
+            <button class="mt-2 px-4 py-2 bg-gray-600 text-white rounded w-full" disabled>{{ __('messages.submit') }}</button>
+        </div>
+    @endif
 
     <div class="space-y-4">
         @foreach ($comments as $comment)

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,8 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
     Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
     Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
     Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
+    Route::post('/gallery/{item}/like', [GalleryController::class, 'likeItem'])->name('gallery.like');
+    Route::post('/gallery/{item}/dislike', [GalleryController::class, 'dislikeItem'])->name('gallery.dislike');
 
     // Password reset routes
     Route::get('/forgot-password', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');


### PR DESCRIPTION
## Summary
- add metadata fields to `gallery_items`
- track gallery item views and restrict comments to logged-in users
- allow liking/disliking gallery items
- show meta info and reaction buttons on gallery item page
- expose new gallery reaction routes

## Testing
- `composer test` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb4571bc832c80d59f45b2ab3d26