### PR TITLE
Add gallery comment replies

### DIFF
--- a/app/Models/GalleryComment.php
+++ b/app/Models/GalleryComment.php
@@ -10,11 +10,21 @@ class GalleryComment extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['gallery_item_id', 'author', 'content', 'likes', 'dislikes'];
+    protected $fillable = ['gallery_item_id', 'author', 'content', 'likes', 'dislikes', 'parent_id'];
 
     public function galleryItem()
     {
         return $this->belongsTo(GalleryItem::class);
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(GalleryComment::class, 'parent_id');
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(GalleryComment::class, 'parent_id');
     }
 
     public function reactions()

--- a/database/migrations/2025_09_06_000000_add_parent_id_to_gallery_comments_table.php
+++ b/database/migrations/2025_09_06_000000_add_parent_id_to_gallery_comments_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('gallery_comments', function (Blueprint $table) {
+            $table->foreignId('parent_id')->nullable()->constrained('gallery_comments')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('gallery_comments', function (Blueprint $table) {
+            $table->dropForeign(['parent_id']);
+            $table->dropColumn('parent_id');
+        });
+    }
+};

--- a/resources/views/gallery/index.blade.php
+++ b/resources/views/gallery/index.blade.php
@@ -9,6 +9,9 @@
         @foreach ($photos as $photo)
             <a href="{{ route('gallery.show', $photo) }}" class="block border border-gray-700 rounded overflow-hidden">
                 <img src="{{ asset('storage/' . $photo->image_path) }}" class="w-full h-full object-cover" />
+                @if($photo->author)
+                    <div class="text-xs text-gray-400 p-1">{{ __('messages.posted_by') }} {{ $photo->author }}</div>
+                @endif
             </a>
         @endforeach
     </div>
@@ -20,6 +23,9 @@
         @foreach ($videos as $video)
             <div class="aspect-video">
                 <iframe src="https://www.youtube.com/embed/{{ \Illuminate\Support\Str::afterLast($video->video_url, '=') }}" class="w-full h-full" frameborder="0" allowfullscreen></iframe>
+                @if($video->author)
+                    <div class="text-xs text-gray-400 p-1">{{ __('messages.posted_by') }} {{ $video->author }}</div>
+                @endif
             </div>
         @endforeach
     </div>

--- a/resources/views/gallery/show.blade.php
+++ b/resources/views/gallery/show.blade.php
@@ -52,6 +52,7 @@
         @foreach ($comments as $comment)
             <div class="bg-black bg-opacity-50 rounded-lg p-4 border border-gray-700">
                 <p class="text-sm text-gray-300">{{ $comment->content }}</p>
+                <div class="text-xs text-gray-400 mt-1">{{ $comment->author }} · {{ $comment->created_at->diffForHumans() }}</div>
                 <div class="text-xs text-gray-500 mt-2 flex items-center gap-2">
                     <form action="{{ route('gallery.comments.like', $comment) }}" method="POST" class="inline">
                         @csrf
@@ -61,6 +62,21 @@
                         @csrf
                         <button>👎 {{ $comment->dislikes }}</button>
                     </form>
+                </div>
+                <div class="ml-4 mt-3 space-y-3">
+                    @foreach($comment->replies as $reply)
+                        <div class="bg-gray-800 bg-opacity-40 rounded-lg p-3 border border-gray-700">
+                            <div class="text-sm text-gray-300">{{ $reply->content }}</div>
+                            <div class="text-xs text-gray-400 mt-1">{{ $reply->author }} · {{ $reply->created_at->diffForHumans() }}</div>
+                        </div>
+                    @endforeach
+                    @if(Auth::guard('metin2')->check())
+                        <form action="{{ route('gallery.comments.reply', $comment) }}" method="POST" class="space-y-2">
+                            @csrf
+                            <textarea name="content" class="w-full p-2 bg-gray-800 text-white rounded" required></textarea>
+                            <button class="px-4 py-2 bg-green-600 text-white rounded">Reply</button>
+                        </form>
+                    @endif
                 </div>
             </div>
         @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware([LanguageMiddleware::class])->group(function () {
     Route::post('/gallery/{item}/comment', [GalleryController::class, 'comment'])->name('gallery.comment');
     Route::post('/gallery/comments/{comment}/like', [GalleryController::class, 'like'])->name('gallery.comments.like');
     Route::post('/gallery/comments/{comment}/dislike', [GalleryController::class, 'dislike'])->name('gallery.comments.dislike');
+    Route::post('/gallery/comments/{comment}/reply', [GalleryController::class, 'reply'])->name('gallery.comments.reply');
     Route::post('/gallery/{item}/like', [GalleryController::class, 'likeItem'])->name('gallery.like');
     Route::post('/gallery/{item}/dislike', [GalleryController::class, 'dislikeItem'])->name('gallery.dislike');
 


### PR DESCRIPTION
## Summary
- show gallery item authors in the listing
- allow replies to gallery comments and display comment authors
- add parent_id relation to gallery comments model
- load comment replies in the controller and add new route
- migration to add `parent_id` to `gallery_comments`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cfaa86a0832c9b6574688af56817